### PR TITLE
feat: add risk scoring to pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ ruff .
 black .
 mypy src
 ```
+
+## Risk Scoring
+
+Each pool is assigned a ``risk_score`` in the range ``1`` (lower risk) to ``3``
+using ``src/stable_yield_lab/risk_scoring.py``. The score averages three
+normalized factors:
+
+1. **Chain reputation** – established networks such as Ethereum receive a
+   higher reputation (lower risk), while lesser known chains start at ``0.5``.
+2. **Protocol audits** – more security audits reduce risk. The contribution is
+   capped at five audits.
+3. **Yield volatility** – unstable historical yields increase risk. Volatility
+   is expected as a 0–1 value.
+
+The three components are combined and scaled to the ``[1, 3]`` range. During
+``Pipeline.run`` the score is computed for every fetched pool.

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 from typing import Any, Protocol
 import pandas as pd
 
+from . import risk_scoring
+
 # -----------------
 # Data Model
 # -----------------
@@ -389,7 +391,9 @@ class Pipeline:
         repo = PoolRepository()
         for s in self.sources:
             try:
-                repo.extend(s.fetch())
+                fetched = s.fetch()
+                scored = [risk_scoring.score_pool(p) for p in fetched]
+                repo.extend(scored)
             except Exception as e:
                 # Log and continue
                 print(f"[WARN] Source {s.__class__.__name__} failed: {e}")
@@ -409,4 +413,5 @@ __all__ = [
     "Pipeline",
     "risk_metrics",
     "reporting",
+    "risk_scoring",
 ]

--- a/src/stable_yield_lab/risk_scoring.py
+++ b/src/stable_yield_lab/risk_scoring.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Heuristic risk scoring for stablecoin yield pools."""
+
+from dataclasses import replace
+from typing import Mapping, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from . import Pool
+
+# Simple reputation mapping per chain. Values range from 0 (unknown) to 1 (blue chip).
+CHAIN_REPUTATION: Mapping[str, float] = {
+    "Ethereum": 1.0,
+    "Arbitrum": 0.9,
+    "Polygon": 0.7,
+    "BSC": 0.6,
+    "Tron": 0.4,
+}
+
+
+def calculate_risk_score(chain_rep: float, audits: int, yield_volatility: float) -> float:
+    """Combine factors into a normalized risk score in the range [1, 3].
+
+    Parameters
+    ----------
+    chain_rep:
+        Reputation of the underlying chain, ``0`` (unknown) to ``1`` (established).
+    audits:
+        Number of protocol security audits. Values above ``5`` are capped.
+    yield_volatility:
+        Normalized measure of historical yield volatility (``0`` stable, ``1`` erratic).
+    """
+
+    # Clamp inputs to expected ranges
+    chain_rep = max(0.0, min(chain_rep, 1.0))
+    audits = max(0, min(audits, 5))
+    yield_volatility = max(0.0, min(yield_volatility, 1.0))
+
+    chain_component = 1.0 - chain_rep  # higher reputation lowers risk
+    audit_component = 1.0 - audits / 5.0  # more audits lower risk
+    vol_component = yield_volatility  # higher volatility increases risk
+
+    raw = (chain_component + audit_component + vol_component) / 3.0
+    return 1.0 + 2.0 * raw
+
+
+def score_pool(
+    pool: "Pool",
+    *,
+    chain_reputation: Mapping[str, float] | None = None,
+    protocol_audits: Mapping[str, int] | None = None,
+    yield_volatility: Mapping[str, float] | None = None,
+) -> "Pool":
+    """Return a new :class:`~stable_yield_lab.Pool` with an updated ``risk_score``.
+
+    Missing mapping entries default to neutral values (``0.5`` reputation,
+    ``0`` audits and ``0`` volatility).
+    """
+
+    chain_rep_map = chain_reputation or CHAIN_REPUTATION
+    audits_map = protocol_audits or {}
+    vol_map = yield_volatility or {}
+
+    chain_rep = chain_rep_map.get(pool.chain, 0.5)
+    audits = audits_map.get(pool.name, 0)
+    vol = vol_map.get(pool.name, 0.0)
+
+    score = calculate_risk_score(chain_rep, audits, vol)
+    return replace(pool, risk_score=score)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-from stable_yield_lab import CSVSource, Pipeline
+from stable_yield_lab import CSVSource, Pipeline, Pool
+from stable_yield_lab.risk_scoring import calculate_risk_score
 
 
 def test_pipeline_loads_sample_csv() -> None:
@@ -8,3 +9,15 @@ def test_pipeline_loads_sample_csv() -> None:
     src = CSVSource(str(csv_path))
     repo = Pipeline([src]).run()
     assert len(repo) > 0
+
+
+def test_pipeline_applies_risk_scoring() -> None:
+    class DummySource:
+        def fetch(self) -> list[Pool]:
+            return [Pool("P1", "Polygon", "USDC", 1.0, 0.1)]
+
+    repo = Pipeline([DummySource()]).run()
+    pools = list(repo._pools)
+    assert len(pools) == 1
+    expected = calculate_risk_score(0.7, 0, 0.0)
+    assert pools[0].risk_score == expected

--- a/tests/test_risk_scoring.py
+++ b/tests/test_risk_scoring.py
@@ -1,0 +1,15 @@
+from stable_yield_lab import Pool
+from stable_yield_lab.risk_scoring import calculate_risk_score, score_pool
+
+
+def test_calculate_risk_score_extremes() -> None:
+    assert calculate_risk_score(1.0, 5, 0.0) == 1.0
+    assert calculate_risk_score(0.0, 0, 1.0) == 3.0
+    # Values outside expected ranges are clamped
+    assert calculate_risk_score(2.0, -1, -5.0) == calculate_risk_score(1.0, 0, 0.0)
+
+
+def test_score_pool_defaults() -> None:
+    pool = Pool("Test", "Unknown", "USDC", 1.0, 0.1)
+    scored = score_pool(pool)
+    assert scored.risk_score == 2.0


### PR DESCRIPTION
## Summary
- implement heuristic risk scoring for pools
- compute risk_score during Pipeline.run
- document methodology and cover edge cases with tests

## Testing
- `pre-commit run -a`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb13f0aa9c832f868bbb1c99c22899