### PR TITLE
feat: add risk-return scatter plot

### DIFF
--- a/src/stable_yield_demo.py
+++ b/src/stable_yield_demo.py
@@ -107,12 +107,20 @@ def main() -> None:
             show=show,
         )
     if "scatter" in args.charts:
-        Visualizer.scatter_tvl_apy(
-            df,
-            title="TVL vs Base APY (bubble=risk)",
-            save_path=str(outdir / "scatter_tvl_apy.png") if outdir else None,
-            show=show,
-        )
+        if "volatility" in df.columns:
+            Visualizer.scatter_risk_return(
+                df,
+                title="Volatility vs Base APY (bubble=TVL)",
+                save_path=str(outdir / "scatter_risk_return.png") if outdir else None,
+                show=show,
+            )
+        else:
+            Visualizer.scatter_tvl_apy(
+                df,
+                title="TVL vs Base APY (bubble=risk)",
+                save_path=str(outdir / "scatter_tvl_apy.png") if outdir else None,
+                show=show,
+            )
     if "chain" in args.charts:
         Visualizer.bar_group_chain(
             by_chain,

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -353,6 +353,46 @@ class Visualizer:
             plt.show()
 
     @staticmethod
+    def scatter_risk_return(
+        df: pd.DataFrame,
+        title: str = "Volatility vs. APY",
+        x_col: str = "volatility",
+        y_col: str = "base_apy",
+        size_col: str = "tvl_usd",
+        annotate: bool = True,
+        *,
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> None:
+        """Plot volatility against APY with bubble sizes scaled by TVL."""
+        if df.empty:
+            return
+        plt = Visualizer._plt()
+        sizes = None
+        if size_col in df.columns:
+            max_val = float(df[size_col].max())
+            if max_val > 0:
+                sizes = (df[size_col] / max_val * 300).tolist()
+        plt.figure(figsize=(10, 6))
+        plt.scatter(df[x_col], df[y_col] * 100.0, s=sizes)
+        if annotate and "name" in df.columns:
+            for _, row in df.iterrows():
+                plt.annotate(
+                    str(row.get("name", "")),
+                    (row[x_col], row[y_col] * 100.0),
+                    textcoords="offset points",
+                    xytext=(5, 5),
+                )
+        plt.xlabel("Volatility")
+        plt.ylabel("APY (%)")
+        plt.title(title)
+        plt.tight_layout()
+        if save_path:
+            plt.savefig(save_path, bbox_inches="tight")
+        if show:
+            plt.show()
+
+    @staticmethod
     def bar_group_chain(
         df_group: pd.DataFrame,
         title: str = "APY (Kettenvergleich)",

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+import matplotlib
+import pandas as pd
+
+from stable_yield_lab import Visualizer
+
+matplotlib.use("Agg")
+
+
+def test_scatter_risk_return_creates_file(tmp_path: Path) -> None:
+    df = pd.DataFrame(
+        {
+            "volatility": [0.1, 0.2, 0.15],
+            "base_apy": [0.05, 0.1, 0.07],
+            "tvl_usd": [1_000_000, 2_000_000, 1_500_000],
+            "name": ["A", "B", "C"],
+        }
+    )
+    out = tmp_path / "risk_return.png"
+    Visualizer.scatter_risk_return(df, save_path=str(out), show=False)
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add Visualizer.scatter_risk_return for risk/return bubble chart
- render risk/return chart in demo when volatility data is available
- document and test risk/return visualization using Agg backend

## Testing
- `pre-commit run -a`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb13eea2e8832f98fa87042d01f43a