### PR TITLE
feat: add risk metrics reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ ruff .
 black .
 mypy src
 ```
+
+## Optional Risk Metrics
+
+Risk analysis utilities rely on the optional [`riskfolio-lib`](https://pypi.org/project/riskfolio-lib/) package.
+Install it via Poetry extras or pip:
+
+```bash
+poetry install -E risk
+# or
+pip install "riskfolio-lib"
+```
+
+The demo writes risk statistics and efficient frontier weights to CSV files
+when the `--outdir` flag is provided. If `riskfolio-lib` is not installed,
+these metrics are skipped and a message is printed.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,11 @@ stablecoin_quant/
 └── pyproject.toml
 ```
 
-Run formatting, linting, and type checks with the provided tooling configs:
+Run formatting, linting, and type checks with pre-commit and pytest:
 
 ```bash
-ruff .
-black .
-mypy src
+poetry run pre-commit run -a
+poetry run pytest -q
 ```
 
 ## Optional Risk Metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ python = ">=3.12,<4.0"
 matplotlib = ">=3.10.6,<4.0.0"
 datetime = ">=5.5,<6.0"
 pandas = ">=2.3.2,<3.0.0"
+riskfolio-lib = {version = ">=6.0.0", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 black = ">=24.0.0"
@@ -22,6 +23,9 @@ pandas-stubs = ">=2.3.2,<3.0.0"
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.extras]
+risk = ["riskfolio-lib"]
 
 [tool.black]
 line-length = 120

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -1,0 +1,108 @@
+import builtins
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+import stable_yield_demo
+from stable_yield_lab import risk_metrics
+
+
+def test_requires_riskfolio(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import: Any = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "riskfolio":
+            raise ImportError("riskfolio missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(RuntimeError):
+        risk_metrics.summary_statistics(pd.DataFrame())
+
+
+def test_summary_and_frontier_shapes(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakePortfolio:
+        def __init__(self, returns: pd.DataFrame) -> None:
+            self.returns = returns
+
+        def assets_stats(self, **kwargs: object) -> None:
+            return None
+
+        def efficient_frontier(
+            self,
+            model: str,
+            rm: str,
+            obj: str,
+            rf: float,
+            l: float,  # noqa: E741 - match riskfolio signature
+            points: int,
+        ) -> pd.DataFrame:
+            return pd.DataFrame([[0.6, 0.4], [0.5, 0.5]], columns=["A", "B"], index=[0, 1])
+
+    def fake_sharpe_risk(returns: pd.DataFrame) -> pd.DataFrame:
+        return pd.DataFrame({"A": [0.1], "B": [0.2]})
+
+    fake_riskfolio = types.SimpleNamespace(Portfolio=FakePortfolio, Sharpe_Risk=fake_sharpe_risk)
+    monkeypatch.setitem(sys.modules, "riskfolio", fake_riskfolio)
+
+    returns = pd.DataFrame({"A": [0.01, 0.02], "B": [0.03, 0.04]})
+    stats = risk_metrics.summary_statistics(returns)
+    frontier = risk_metrics.efficient_frontier(returns)
+
+    assert list(stats.columns) == ["A", "B"]
+    assert frontier.shape == (2, 2)
+    assert all(abs(frontier.sum(axis=1) - 1.0) < 1e-9)
+
+
+def test_demo_writes_risk_csvs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stats_df = pd.DataFrame({"A": [0.1]})
+    frontier_df = pd.DataFrame({"A": [1.0]})
+    monkeypatch.setattr(risk_metrics, "summary_statistics", lambda df: stats_df)
+    monkeypatch.setattr(risk_metrics, "efficient_frontier", lambda df: frontier_df)
+
+    csv_path = Path(__file__).resolve().parents[1] / "src/sample_pools.csv"
+    outdir = tmp_path / "out"
+    argv = [
+        "prog",
+        "--csv",
+        str(csv_path),
+        "--outdir",
+        str(outdir),
+        "--no-show",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    stable_yield_demo.main()
+
+    assert (outdir / "risk_stats.csv").is_file()
+    assert (outdir / "efficient_frontier.csv").is_file()
+
+
+def test_demo_skips_risk_metrics_when_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(_: pd.DataFrame) -> pd.DataFrame:  # pragma: no cover - raises
+        raise RuntimeError("riskfolio missing")
+
+    monkeypatch.setattr(risk_metrics, "summary_statistics", fail)
+    monkeypatch.setattr(risk_metrics, "efficient_frontier", fail)
+
+    csv_path = Path(__file__).resolve().parents[1] / "src/sample_pools.csv"
+    outdir = tmp_path / "out"
+    argv = [
+        "prog",
+        "--csv",
+        str(csv_path),
+        "--outdir",
+        str(outdir),
+        "--no-show",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    stable_yield_demo.main()
+
+    assert not (outdir / "risk_stats.csv").exists()
+    assert not (outdir / "efficient_frontier.csv").exists()

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -67,15 +67,9 @@ def test_demo_writes_risk_csvs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 
     csv_path = Path(__file__).resolve().parents[1] / "src/sample_pools.csv"
     outdir = tmp_path / "out"
-    argv = [
-        "prog",
-        "--csv",
-        str(csv_path),
-        "--outdir",
-        str(outdir),
-        "--no-show",
-    ]
-    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("STABLE_YIELD_CSV", str(csv_path))
+    monkeypatch.setenv("STABLE_YIELD_OUTDIR", str(outdir))
+    monkeypatch.setattr(sys, "argv", ["prog"])
     stable_yield_demo.main()
 
     assert (outdir / "risk_stats.csv").is_file()
@@ -93,15 +87,9 @@ def test_demo_skips_risk_metrics_when_missing(
 
     csv_path = Path(__file__).resolve().parents[1] / "src/sample_pools.csv"
     outdir = tmp_path / "out"
-    argv = [
-        "prog",
-        "--csv",
-        str(csv_path),
-        "--outdir",
-        str(outdir),
-        "--no-show",
-    ]
-    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setenv("STABLE_YIELD_CSV", str(csv_path))
+    monkeypatch.setenv("STABLE_YIELD_OUTDIR", str(outdir))
+    monkeypatch.setattr(sys, "argv", ["prog"])
     stable_yield_demo.main()
 
     assert not (outdir / "risk_stats.csv").exists()


### PR DESCRIPTION
## Summary
- compute and export risk metrics in demo
- document riskfolio dependency
- test risk metrics with mocked riskfolio
- gracefully handle missing riskfolio library and skip CSV outputs

## Testing
- `python -m pre_commit run -a`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb13e49878832faffd64f8ee09fbe5