### PR TITLE
feat: add historical csv source and timeseries pipeline

### DIFF
--- a/src/sample_yields.csv
+++ b/src/sample_yields.csv
@@ -1,0 +1,5 @@
+timestamp,name,period_return
+2024-01-01,PoolA,0.01
+2024-01-08,PoolA,0.011
+2024-01-01,PoolB,0.008
+2024-01-15,PoolB,0.007

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -92,6 +92,42 @@ class PoolRepository:
         return iter(self._pools)
 
 
+# Additional data model for time-series returns
+
+
+@dataclass(frozen=True)
+class PoolReturn:
+    """Periodic return observation for a given pool."""
+
+    name: str
+    timestamp: pd.Timestamp
+    period_return: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "timestamp": self.timestamp,
+            "period_return": self.period_return,
+        }
+
+
+class ReturnRepository:
+    """Collection of :class:`PoolReturn` rows with pivot helper."""
+
+    def __init__(self, rows: Iterable[PoolReturn] | None = None) -> None:
+        self._rows: list[PoolReturn] = list(rows) if rows else []
+
+    def extend(self, rows: Iterable[PoolReturn]) -> None:
+        self._rows.extend(rows)
+
+    def to_timeseries(self) -> pd.DataFrame:
+        if not self._rows:
+            return pd.DataFrame()
+        df = pd.DataFrame([r.to_dict() for r in self._rows])
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        return df.pivot(index="timestamp", columns="name", values="period_return").sort_index()
+
+
 # -----------------
 # Data Sources API
 # -----------------
@@ -129,6 +165,30 @@ class CSVSource:
                 )
             )
         return pools
+
+
+class HistoricalCSVSource:
+    """Load periodic returns from a CSV with timestamp, name and period_return."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    def fetch(self) -> list[PoolReturn]:
+        df = pd.read_csv(self.path)
+        required = {"timestamp", "name", "period_return"}
+        missing = required.difference(df.columns)
+        if missing:
+            raise ValueError(f"CSV missing columns: {missing}")
+        df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
+        rows = [
+            PoolReturn(
+                name=str(r["name"]),
+                timestamp=pd.Timestamp(r["timestamp"]),
+                period_return=float(r["period_return"]),
+            )
+            for _, r in df.iterrows()
+        ]
+        return rows
 
 
 # Stubs for real adapters you can implement:
@@ -382,7 +442,7 @@ class Visualizer:
 class Pipeline:
     """Composable pipeline: fetch -> repository -> filter -> metrics -> visuals"""
 
-    def __init__(self, sources: list[DataSource]) -> None:
+    def __init__(self, sources: list[Any]) -> None:
         self.sources = sources
 
     def run(self) -> PoolRepository:
@@ -395,12 +455,24 @@ class Pipeline:
                 print(f"[WARN] Source {s.__class__.__name__} failed: {e}")
         return repo
 
+    def run_history(self) -> pd.DataFrame:
+        repo = ReturnRepository()
+        for s in self.sources:
+            try:
+                repo.extend(s.fetch())
+            except Exception as e:
+                print(f"[WARN] Source {s.__class__.__name__} failed: {e}")
+        return repo.to_timeseries()
+
 
 __all__ = [
     "Pool",
     "PoolRepository",
+    "PoolReturn",
+    "ReturnRepository",
     "DataSource",
     "CSVSource",
+    "HistoricalCSVSource",
     "DefiLlamaSource",
     "MorphoSource",
     "BeefySource",

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pandas as pd
+
+from stable_yield_lab import HistoricalCSVSource, Pipeline
+
+
+def test_historical_csv_parsing_and_alignment() -> None:
+    csv_path = Path(__file__).resolve().parent.parent / "src" / "sample_yields.csv"
+    src = HistoricalCSVSource(str(csv_path))
+    df = Pipeline([src]).run_history()
+    assert list(df.columns) == ["PoolA", "PoolB"]
+    assert df.index.tz is not None
+    assert df.shape == (3, 2)
+    assert pd.isna(df.loc[pd.Timestamp("2024-01-08", tz="UTC"), "PoolB"])
+    assert pd.isna(df.loc[pd.Timestamp("2024-01-15", tz="UTC"), "PoolA"])
+    assert df.loc[pd.Timestamp("2024-01-08", tz="UTC"), "PoolA"] == 0.011
+    assert df.loc[pd.Timestamp("2024-01-01", tz="UTC"), "PoolB"] == 0.008


### PR DESCRIPTION
## Summary
- add `PoolReturn` dataclass and `ReturnRepository` for time-series storage
- implement `HistoricalCSVSource` and pipeline `run_history` to produce wide return frames
- test historical CSV parsing and alignment

## Testing
- `poetry run pre-commit run -a`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb13d5af9c832fbbbfb14597c8b565