### PR TITLE
feat: add Codex integration workflow

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,0 +1,82 @@
+name: Codex Integration
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Send diff to Codex for review
+        env:
+          CODEX_API_URL: ${{ secrets.CODEX_API_URL }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.sha }}
+          git diff ${{ github.event.pull_request.base.sha }}..${{ github.sha }} > pr.diff
+          curl -sS -X POST "$CODEX_API_URL/review" \
+            -H "Authorization: Bearer $CODEX_API_KEY" \
+            -H "Content-Type: text/plain" \
+            --data-binary @pr.diff
+
+  analyze-issue:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Analyze issue with Codex
+        uses: actions/github-script@v7
+        env:
+          CODEX_API_URL: ${{ secrets.CODEX_API_URL }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        with:
+          script: |
+            const fetch = require('node-fetch');
+            const res = await fetch(`${process.env.CODEX_API_URL}/issues`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${process.env.CODEX_API_KEY}`
+              },
+              body: JSON.stringify({
+                title: context.payload.issue.title,
+                body: context.payload.issue.body
+              })
+            });
+            core.info(await res.text());
+
+  issue-resolution:
+    if: github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send comment thread to Codex
+        uses: actions/github-script@v7
+        env:
+          CODEX_API_URL: ${{ secrets.CODEX_API_URL }}
+          CODEX_API_KEY: ${{ secrets.CODEX_API_KEY }}
+        with:
+          script: |
+            const fetch = require('node-fetch');
+            const issue = context.payload.issue;
+            const comment = context.payload.comment;
+            const res = await fetch(`${process.env.CODEX_API_URL}/comments`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${process.env.CODEX_API_KEY}`
+              },
+              body: JSON.stringify({
+                title: issue.title,
+                body: issue.body,
+                comment: comment.body
+              })
+            });
+            core.info(await res.text());


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to integrate Codex for PR reviews, issue triage, and comment analysis

## Testing
- ⚠️ `poetry run pre-commit run -a` (fails: trailing whitespace / formatting in unrelated files)
- ✅ `poetry run pre-commit run --files .github/workflows/codex.yml`
- ✅ `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19c548f48832fbad55381d14107f5