### PR TITLE
docs: add AGENTS instructions for code, tests, and CI

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,18 @@
+# CI and Workflow Guidelines
+
+These instructions cover files in `.github/` including GitHub Actions workflows.
+
+## CI Workflows
+- Use GitHub Actions to run pre-commit, tests, and coverage on Python 3.12.
+- Keep workflows minimal and modular; prefer composite actions when steps repeat.
+- When altering triggers or job matrices, document the rationale in comments.
+- Validate workflow changes with `act` or via a pull request before merging.
+
+## Codex and Automation
+- Automation scripts should respect repository `AGENTS.md` instructions and maintain determinism.
+- Avoid committing secrets; reference credentials through encrypted repository secrets.
+- Reusable workflows should expose parameters clearly and default to safe settings.
+
+## Reviews
+- CI changes require review from maintainers familiar with infrastructure.
+- Ensure any new workflow has a matching entry in documentation if it affects contributors.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,25 @@
+# Implementation Guidelines
+
+These instructions apply to all Python modules under `src/`.
+
+## Coding Conventions
+- Follow PEP 8 with 4‑space indents and a 120‑character line limit.
+- Type hints are required for all public functions and dataclasses.
+- Keep modules small, composable, and documented with clear docstrings.
+- Favor pure functions; avoid implicit global state.
+
+## Quantitative Development
+- Clearly state mathematical formulas and financial assumptions in comments or docstrings.
+- Use vectorised NumPy/Pandas operations when practical to ensure performance on large datasets.
+- Validate units and currency denominations; avoid magic numbers.
+- Ensure algorithms are numerically stable and reproducible.
+
+## Workflow
+1. Define requirements.
+2. Write failing tests under `tests/`.
+3. Implement or update code until tests pass.
+4. Refactor and document.
+
+## Data Handling
+- Keep sample datasets small and version‑controlled; never commit secrets.
+- Wrap external API calls with adapters that can be mocked in tests.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,18 @@
+# Testing Guidelines
+
+These instructions govern all tests under `tests/`.
+
+## Practices
+- Use `pytest` with files named `test_*.py`.
+- Write tests before implementation when possible.
+- Prefer parametrised tests and fixtures to reduce duplication.
+- Mock network and filesystem interactions; tests must be deterministic.
+
+## Coverage
+- Aim for comprehensive coverage of new or changed modules.
+- For quantitative logic, include edge cases and numerical stability checks.
+- Measure coverage with `pytest --cov` and keep reports clean of missing lines.
+
+## Execution
+- Ensure `poetry run pytest` passes locally before committing.
+- Keep test data small and checked into version control when feasible.


### PR DESCRIPTION
## Summary
- document implementation conventions and quant-specific workflow under `src/`
- outline test practices and coverage expectations in `tests/`
- add CI and automation guidance for `.github` workflows

## Testing
- `poetry run pre-commit run --files .github/AGENTS.md src/AGENTS.md tests/AGENTS.md`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1b4b6b274832fbcade868b4918665