### PR TITLE
ci: restrict codex workflow permissions

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -1,5 +1,9 @@
 name: Codex Integration
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -30,6 +34,8 @@ jobs:
 
   analyze-issue:
     if: github.event_name == 'issues'
+    permissions:
+      issues: read
     runs-on: ubuntu-latest
     steps:
       - name: Analyze issue with Codex
@@ -55,6 +61,8 @@ jobs:
 
   issue-resolution:
     if: github.event_name == 'issue_comment'
+    permissions:
+      issues: read
     runs-on: ubuntu-latest
     steps:
       - name: Send comment thread to Codex


### PR DESCRIPTION
## Summary
- restrict Codex workflow to read-only permissions
- limit issue-related jobs to issues: read only

## Testing
- `poetry run pre-commit run --files .github/workflows/codex.yml`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1b4b16508832faddd54d2322762bb