### PR TITLE
feat: add line chart visualizations for yield and NAV

### DIFF
--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -643,6 +643,68 @@ class Visualizer:
             plt.show()
 
     @staticmethod
+    def line_yield(
+        ts: pd.DataFrame,
+        title: str = "Yield Over Time",
+        *,
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> None:
+        """Plot yield time series for one or multiple pools.
+
+        Parameters
+        ----------
+        ts:
+            DataFrame with datetime index and columns representing pools. Values
+            should be in decimal form (e.g. 0.05 for 5%).
+        title:
+            Chart title.
+        save_path:
+            Optional path to save the figure.
+        show:
+            Whether to display the figure.
+        """
+        if ts.empty:
+            return
+        plt = Visualizer._plt()
+        plt.figure(figsize=(10, 6))
+        for col in ts.columns:
+            plt.plot(ts.index, ts[col] * 100.0, label=str(col))
+        plt.xlabel("Date")
+        plt.ylabel("APY (%)")
+        plt.title(title)
+        if ts.shape[1] > 1:
+            plt.legend()
+        plt.tight_layout()
+        if save_path:
+            plt.savefig(save_path, bbox_inches="tight")
+        if show:
+            plt.show()
+
+    @staticmethod
+    def line_nav(
+        nav: pd.Series,
+        title: str = "Net Asset Value",
+        *,
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> None:
+        """Plot net asset value time series."""
+        if nav.empty:
+            return
+        plt = Visualizer._plt()
+        plt.figure(figsize=(10, 6))
+        plt.plot(nav.index, nav.values)
+        plt.xlabel("Date")
+        plt.ylabel("NAV")
+        plt.title(title)
+        plt.tight_layout()
+        if save_path:
+            plt.savefig(save_path, bbox_inches="tight")
+        if show:
+            plt.show()
+
+    @staticmethod
     def bar_group_chain(
         df_group: pd.DataFrame,
         title: str = "APY (Kettenvergleich)",

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -20,3 +20,26 @@ def test_scatter_risk_return_creates_file(tmp_path: Path) -> None:
     out = tmp_path / "risk_return.png"
     Visualizer.scatter_risk_return(df, save_path=str(out), show=False)
     assert out.exists() and out.stat().st_size > 0
+
+
+def test_line_yield_creates_file(tmp_path: Path) -> None:
+    ts = pd.DataFrame(
+        {
+            "pool_a": [0.05, 0.06, 0.055],
+            "pool_b": [0.04, 0.045, 0.05],
+        },
+        index=pd.date_range("2023-01-01", periods=3, freq="D"),
+    )
+    out = tmp_path / "yield.png"
+    Visualizer.line_yield(ts, save_path=str(out), show=False)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_line_nav_creates_file(tmp_path: Path) -> None:
+    nav = pd.Series(
+        [100.0, 101.5, 102.0],
+        index=pd.date_range("2023-01-01", periods=3, freq="D"),
+    )
+    out = tmp_path / "nav.png"
+    Visualizer.line_nav(nav, save_path=str(out), show=False)
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `Visualizer.line_yield` and `Visualizer.line_nav` helpers to plot yield and NAV time series
- test new line chart methods to ensure plots render and save correctly

## Testing
- `poetry run pre-commit run -a`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ea160874832f8c0a664aba8b9788