### PR TITLE
Add scheduled workflow for demo image artifacts

### DIFF
--- a/.github/workflows/daily-demo-images.yml
+++ b/.github/workflows/daily-demo-images.yml
@@ -1,0 +1,40 @@
+name: Daily Demo Images
+
+# Runs daily to refresh the published demo charts used for documentation assets.
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  generate-demo-images:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Generate demo artifacts
+        env:
+          MPLBACKEND: Agg
+        run: |
+          python src/stable_yield_demo.py configs/demo.toml
+
+      - name: Upload demo images
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-demo-images
+          path: |
+            docs/*.png
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a Daily Demo Images workflow triggered nightly and on demand
- set up Python 3.12, install dependencies, and run the stable_yield_demo script headlessly
- publish the generated PNG charts from docs/ as a build artifact for reuse outside PRs

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c99c45c86c832fb2f8681e5b9ee0ad