### PR TITLE
ci: publish coverage report via GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
   build-test:
     runs-on: ubuntu-latest
@@ -39,10 +43,90 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=stable_yield_lab --cov-report=xml --cov-report=term-missing
+          pytest --cov=stable_yield_lab --cov-report=xml --cov-report=html --cov-report=term-missing
+
+      - name: Prepare coverage site artifact
+        run: |
+          python - <<'PY'
+import json
+import pathlib
+import xml.etree.ElementTree as ET
+
+coverage_xml = pathlib.Path("coverage.xml")
+root = ET.fromstring(coverage_xml.read_text())
+line_rate = float(root.get("line-rate", 0.0))
+percentage = round(line_rate * 100, 2)
+
+def pick_color(pct: float) -> str:
+    if pct >= 90:
+        return "brightgreen"
+    if pct >= 75:
+        return "green"
+    if pct >= 60:
+        return "yellowgreen"
+    if pct >= 45:
+        return "yellow"
+    if pct >= 30:
+        return "orange"
+    return "red"
+
+badge = {
+    "schemaVersion": 1,
+    "label": "coverage",
+    "message": f"{percentage:.1f}%",
+    "color": pick_color(percentage),
+}
+
+site_dir = pathlib.Path("coverage-site")
+site_dir.mkdir(parents=True, exist_ok=True)
+(site_dir / "badge.json").write_text(json.dumps(badge))
+PY
+          rm -rf coverage-site/report
+          mkdir -p coverage-site
+          cp -r htmlcov coverage-site/report
+          cat <<'HTML' > coverage-site/index.html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=report/index.html" />
+    <title>Coverage report</title>
+  </head>
+  <body>
+    <p><a href="report/index.html">View the coverage report.</a></p>
+  </body>
+</html>
+HTML
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml
+
+      - name: Upload HTML coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: coverage-site/report
+
+      - name: Upload coverage site for Pages
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage-site
+
+  deploy-coverage:
+    needs: build-test
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/gh-pages'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # stablecoin_quant
 
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/aujl/stablecoin_quant/gh-pages/coverage/badge.json)](https://aujl.github.io/stablecoin_quant/coverage/)
+
 Experimental toolkit for analyzing and visualizing yields on stablecoin pools.
+
+Latest test coverage is published automatically from CI to [GitHub Pages](https://aujl.github.io/stablecoin_quant/coverage/), which hosts the HTML report alongside the badge metadata for the shield above.
 
 ## Project Layout
 


### PR DESCRIPTION
## Summary
- extend the CI workflow to produce HTML coverage output, badge metadata, and a Pages-ready artifact
- deploy the generated coverage site to GitHub Pages on pushes to tracked branches
- expose the live coverage badge and report link from the README

## Testing
- poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c99c4f1fb8832fb4eeccadb9510fbe