### PR TITLE
feat: add realised apy horizons to demo reporting

### DIFF
--- a/configs/demo.toml
+++ b/configs/demo.toml
@@ -21,3 +21,7 @@ charts = ["bar", "scatter", "chain"]
 top_n = 10
 perf_fee_bps = 0.0
 mgmt_fee_bps = 0.0
+
+[reporting.realised_apy_lookbacks]
+"last 2 weeks" = "14D"
+"last 52 weeks" = "52W"

--- a/src/stable_yield_demo.py
+++ b/src/stable_yield_demo.py
@@ -6,6 +6,8 @@ import tomllib
 from pathlib import Path
 from typing import Any, cast
 
+import pandas as pd
+
 from stable_yield_lab import (
     CSVSource,
     HistoricalCSVSource,
@@ -16,6 +18,16 @@ from stable_yield_lab import (
     risk_metrics,
 )
 from stable_yield_lab.reporting import cross_section_report
+
+
+def _normalise_lookbacks(raw: Any) -> dict[str, Any]:
+    """Coerce configuration lookback definitions into a labelled mapping."""
+
+    if isinstance(raw, dict):
+        return {str(k): v for k, v in raw.items()}
+    if isinstance(raw, list):
+        return {str(v): v for v in raw}
+    return {}
 
 
 def load_config(path: str | Path | None) -> dict[str, Any]:
@@ -45,7 +57,12 @@ def load_config(path: str | Path | None) -> dict[str, Any]:
             # "stablecoins": ["USDC"]
         },
         "output": {"outdir": None, "show": True, "charts": ["bar", "scatter", "chain"]},
-        "reporting": {"top_n": 10, "perf_fee_bps": 0.0, "mgmt_fee_bps": 0.0},
+        "reporting": {
+            "top_n": 10,
+            "perf_fee_bps": 0.0,
+            "mgmt_fee_bps": 0.0,
+            "realised_apy_lookbacks": {"last 2 weeks": "14D", "last 52 weeks": "52W"},
+        },
     }
 
     cfg_path = Path(path) if path else None
@@ -91,6 +108,11 @@ def main() -> None:
         except ValueError:
             pass
 
+    lookbacks_cfg = _normalise_lookbacks(cfg.get("reporting", {}).get("realised_apy_lookbacks", {}))
+    realised_apys: pd.DataFrame | None = None
+    nav_ts: pd.DataFrame | None = None
+    yield_ts_pct: pd.DataFrame | None = None
+
     # Load data
     csv_path = cfg["csv"]["path"]
     src = CSVSource(path=csv_path)
@@ -129,6 +151,26 @@ def main() -> None:
     except Exception as exc:
         print(f"Skipping risk metrics: {exc}")
 
+    if cfg.get("yields_csv"):
+        hist_src = HistoricalCSVSource(str(cfg["yields_csv"]))
+        returns_ts = Pipeline([hist_src]).run_history()
+        if not returns_ts.empty:
+            initial = float(cfg.get("initial_investment", 1.0))
+            nav_ts = performance.nav_trajectories(returns_ts, initial_investment=initial)
+            yield_ts_pct = performance.yield_trajectories(returns_ts) * 100.0
+            if lookbacks_cfg:
+                apy_table = performance.horizon_apys(nav_ts, lookbacks=lookbacks_cfg, value_type="nav")
+                if not apy_table.empty:
+                    apy_table = apy_table.rename(
+                        columns={label: f"Realised APY ({label})" for label in apy_table.columns}
+                    )
+                    realised_apys = apy_table
+                    if not df.empty:
+                        df = df.merge(apy_table, left_on="name", right_index=True, how="left")
+                    pretty = apy_table.mul(100.0).round(2)
+                    print("Realised APY horizons (annualised, %):")
+                    print(pretty.to_string())
+
     if outdir:
         outdir.mkdir(parents=True, exist_ok=True)
         cross_section_report(
@@ -137,6 +179,7 @@ def main() -> None:
             perf_fee_bps=float(cfg.get("reporting", {}).get("perf_fee_bps", 0.0)),
             mgmt_fee_bps=float(cfg.get("reporting", {}).get("mgmt_fee_bps", 0.0)),
             top_n=top_n,
+            horizon_apys=realised_apys,
         )
         if stats is not None:
             stats.to_csv(outdir / "risk_stats.csv")
@@ -167,19 +210,15 @@ def main() -> None:
         )
 
     # Performance trajectories from historical yields
-    if cfg.get("yields_csv"):
-        hist_src = HistoricalCSVSource(str(cfg["yields_csv"]))
-        returns_ts = Pipeline([hist_src]).run_history()
-        initial = float(cfg.get("initial_investment", 1.0))
-        nav_ts = performance.nav_trajectories(returns_ts, initial_investment=initial)
-        yield_ts = performance.yield_trajectories(returns_ts) * 100.0
+    if yield_ts_pct is not None:
         Visualizer.line_chart(
-            yield_ts,
+            yield_ts_pct,
             title="Yield over time",
             ylabel="Yield (%)",
             save_path=str(outdir / "yield_vs_time.png") if outdir else None,
             show=show,
         )
+    if nav_ts is not None:
         Visualizer.line_chart(
             nav_ts,
             title="NAV over time",

--- a/src/stable_yield_lab/performance.py
+++ b/src/stable_yield_lab/performance.py
@@ -8,6 +8,10 @@ compounding identity :math:`G_t = \prod_{i=1}^t (1 + r_i)`.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from numbers import Integral
+from typing import Literal
+
 import pandas as pd
 
 
@@ -158,3 +162,146 @@ def yield_trajectories(returns: pd.DataFrame) -> pd.DataFrame:
     if returns.empty:
         return returns.copy()
     return (1.0 + returns.fillna(0.0)).cumprod() - 1.0
+
+
+def horizon_apys(
+    trajectory: pd.DataFrame | pd.Series,
+    *,
+    lookbacks: Mapping[str, int | str | pd.Timedelta],
+    value_type: Literal["nav", "yield"] = "nav",
+    periods_per_year: float | None = None,
+) -> pd.DataFrame:
+    r"""Convert NAV or cumulative yield paths into annualised realised APYs.
+
+    For a lookback window of length :math:`L` (in years) the realised annual
+    percentage yield (APY) is computed from the growth factor :math:`G`
+    observed over the window:
+
+    .. math::
+       \text{APY} = G^{1/L} - 1, \qquad G = \frac{\text{NAV}_{t}}{\text{NAV}_{t-L}}.
+
+    The function accepts NAV trajectories (level data) or cumulative yields. In
+    the latter case the input is first converted into NAV space via
+    ``1 + cumulative_yield`` so that growth factors remain comparable across
+    pools regardless of the initial capital. Lookbacks may be provided either
+    as positive integers (number of periods) or as pandas-compatible
+    ``Timedelta`` specifications such as ``"52W"`` or ``"90D"``.
+
+    Parameters
+    ----------
+    trajectory:
+        NAV levels or cumulative yields indexed by time with one column per
+        asset.
+    lookbacks:
+        Mapping of human-readable labels to lookback definitions. Integer
+        values are interpreted as a number of observation periods; strings and
+        :class:`~pandas.Timedelta` objects are converted via
+        :func:`pandas.to_timedelta`.
+    value_type:
+        ``"nav"`` when ``trajectory`` already represents NAV levels, or
+        ``"yield"`` when the input is cumulative yield (``G - 1``).
+    periods_per_year:
+        Optional frequency override used when lookbacks are specified in
+        integer periods and cannot be inferred from the index. If omitted the
+        function attempts to infer the observation frequency from a
+        ``DatetimeIndex``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Realised APYs expressed as decimal fractions. The rows correspond to
+        asset names (trajectory columns) and columns align with the provided
+        ``lookbacks`` labels.
+
+    Raises
+    ------
+    ValueError
+        If an integer lookback is provided without a resolvable
+        ``periods_per_year`` and the index frequency cannot be inferred, or if
+        any lookback definition is non-positive.
+    TypeError
+        When a time-based lookback is requested but the index is not a
+        ``DatetimeIndex``.
+    """
+
+    if isinstance(trajectory, pd.Series):
+        name = trajectory.name or "value"
+        data = trajectory.astype(float).to_frame(name=name)
+    else:
+        data = trajectory.astype(float)
+
+    if data.empty:
+        return pd.DataFrame(index=data.columns, columns=list(lookbacks.keys()), dtype=float)
+
+    if not lookbacks:
+        return pd.DataFrame(index=data.columns, dtype=float)
+
+    nav = data.sort_index()
+    nav = nav.astype(float)
+
+    value_type = value_type.lower()
+    if value_type == "yield":
+        nav = 1.0 + nav
+    elif value_type != "nav":
+        raise ValueError(f"Unsupported value_type '{value_type}'. Use 'nav' or 'yield'.")
+
+    idx = nav.index
+    period_length: pd.Timedelta | None = None
+    if isinstance(idx, pd.DatetimeIndex) and len(idx) >= 2:
+        diffs = idx.to_series().diff().dropna()
+        if not diffs.empty:
+            median = diffs.median()
+            if pd.notna(median) and median > pd.Timedelta(0):
+                period_length = pd.Timedelta(median)
+
+    per_year = float(periods_per_year) if periods_per_year is not None else None
+    if per_year is None and period_length is not None:
+        per_year = float(pd.Timedelta(days=365) / period_length)
+
+    assets = list(nav.columns)
+    result = pd.DataFrame(index=assets, columns=list(lookbacks.keys()), dtype=float)
+    latest = nav.iloc[-1]
+
+    year_td = pd.Timedelta(days=365)
+
+    for label, raw_lookback in lookbacks.items():
+        if isinstance(raw_lookback, Integral):
+            periods = int(raw_lookback)
+            if periods <= 0:
+                raise ValueError(f"Lookback '{label}' must be positive; received {periods}.")
+            if len(nav) <= periods:
+                continue
+            base = nav.iloc[-(periods + 1)]
+            if per_year is None:
+                raise ValueError(
+                    "periods_per_year must be provided or inferrable when using integer lookbacks"
+                )
+            years = periods / per_year
+        else:
+            try:
+                delta = pd.to_timedelta(raw_lookback)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"Invalid lookback '{label}': {raw_lookback!r}") from exc
+            if delta <= pd.Timedelta(0):
+                raise ValueError(f"Lookback '{label}' must be positive; received {raw_lookback!r}.")
+            if not isinstance(idx, pd.DatetimeIndex):
+                raise TypeError("Timedelta lookbacks require a DatetimeIndex.")
+            target = idx[-1] - delta
+            window = nav.loc[:target]
+            if window.empty:
+                continue
+            base = window.iloc[-1]
+            years = float(delta / year_td)
+
+        if years <= 0:
+            continue
+
+        growth = latest / base
+        valid = (base > 0) & (latest > 0) & growth.notna() & (growth > 0)
+        apy_series = pd.Series(float("nan"), index=assets)
+        if valid.any():
+            exponent = 1.0 / years
+            apy_series.loc[valid] = growth.loc[valid].pow(exponent) - 1.0
+        result[label] = apy_series
+
+    return result

--- a/tests/test_demo_config.py
+++ b/tests/test_demo_config.py
@@ -1,4 +1,9 @@
-from stable_yield_demo import load_config
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stable_yield_demo import load_config, main
 
 
 def test_loads_config_file() -> None:
@@ -6,3 +11,23 @@ def test_loads_config_file() -> None:
     assert cfg["csv"]["path"].endswith("sample_pools.csv")
     assert cfg["output"]["show"] is False
     assert cfg["output"]["charts"] == ["bar", "scatter", "chain"]
+    assert "realised_apy_lookbacks" in cfg["reporting"]
+    assert cfg["reporting"]["realised_apy_lookbacks"]["last 52 weeks"] == "52W"
+
+
+def test_demo_outputs_realised_apy_columns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("STABLE_YIELD_CONFIG", "configs/demo.toml")
+    monkeypatch.setenv("STABLE_YIELD_OUTDIR", str(tmp_path))
+
+    main()
+
+    captured = capsys.readouterr()
+    assert "Realised APY (last 52 weeks)" in captured.out
+
+    pools_path = tmp_path / "pools.csv"
+    assert pools_path.is_file()
+    pools_df = pd.read_csv(pools_path)
+    assert "Realised APY (last 2 weeks)" in pools_df.columns
+    assert "Realised APY (last 52 weeks)" in pools_df.columns

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -43,6 +43,45 @@ def test_nav_and_yield_trajectories(tmp_path: Path) -> None:
     assert yield_path.is_file()
 
 
+def test_horizon_apys_from_nav_and_yield() -> None:
+    idx = pd.date_range("2024-01-01", periods=5, freq="7D", tz="UTC")
+    nav = pd.DataFrame(
+        {
+            "PoolA": [100.0, 101.0, 104.0, 108.0, 110.0],
+            "PoolB": [100.0, 98.0, 99.0, 100.0, 101.0],
+        },
+        index=idx,
+    )
+    lookbacks = {
+        "last 2 weeks": "14D",
+        "last 2 periods": 2,
+        "last 52 weeks": "364D",
+    }
+
+    apy_nav = performance.horizon_apys(nav, lookbacks=lookbacks, value_type="nav")
+
+    latest = nav.iloc[-1]
+    base_2w = nav.loc[: idx[-1] - pd.Timedelta(days=14)].iloc[-1]
+    years_2w = pd.Timedelta(days=14) / pd.Timedelta(days=365)
+    expected_2w = (latest / base_2w) ** (1.0 / years_2w) - 1.0
+    expected_2w.name = "last 2 weeks"
+
+    base_2p = nav.iloc[-(2 + 1)]
+    periods_per_year = pd.Timedelta(days=365) / (idx[1] - idx[0])
+    years_2p = 2 / periods_per_year
+    expected_2p = (latest / base_2p) ** (1.0 / years_2p) - 1.0
+    expected_2p.name = "last 2 periods"
+
+    pd.testing.assert_series_equal(apy_nav["last 2 weeks"], expected_2w)
+    pd.testing.assert_series_equal(apy_nav["last 2 periods"], expected_2p)
+    assert pd.isna(apy_nav.loc["PoolA", "last 52 weeks"])
+    assert pd.isna(apy_nav.loc["PoolB", "last 52 weeks"])
+
+    yields = nav / nav.iloc[0] - 1.0
+    apy_yield = performance.horizon_apys(yields, lookbacks=lookbacks, value_type="yield")
+    pd.testing.assert_frame_equal(apy_nav, apy_yield)
+
+
 def test_cumulative_return_matches_manual_compounding() -> None:
     dates = pd.date_range("2024-01-01", periods=3, freq="D")
     series = pd.Series([0.1, -0.05, 0.02], index=dates)


### PR DESCRIPTION
## Summary
- add a `performance.horizon_apys` helper to annualise NAV or cumulative-yield trajectories across configurable lookbacks
- normalise lookback configuration in the demo, compute realised APYs from historical NAVs, and persist those columns in console output and CSV exports
- allow `cross_section_report` to merge optional realised APY columns and extend the test suite for the new helper and demo output expectations

## Testing
- poetry run pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9ae09759c832f8cbcace21d945ee1