### PR TITLE
docs: align walkthrough with nav/yield trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,38 @@ Run the demo with sample historical returns to generate Net Asset Value (NAV) an
 poetry run python src/stable_yield_demo.py configs/demo.toml
 ```
 
-The script applies `stable_yield_lab.performance.nav_curve` and `performance.yield_curve` to compute time-series performance.
-`Visualizer.plot_nav` and `Visualizer.plot_yield` render the NAV trajectory and annualized yields.
+The script applies `stable_yield_lab.performance.nav_trajectories` and `performance.yield_trajectories` to compute time-series performance.
+`Visualizer.line_chart` renders both the NAV and cumulative yield trajectories with a shared helper.
+
+Interactively explore the same calculations from Python:
+
+```pycon
+>>> from pathlib import Path
+>>> from tempfile import TemporaryDirectory
+>>> import pandas as pd
+>>> from stable_yield_lab import Visualizer, performance
+>>> yields_df = pd.read_csv("src/sample_yields.csv", parse_dates=["timestamp"])
+>>> returns = yields_df.pivot(index="timestamp", columns="name", values="period_return")
+>>> nav = performance.nav_trajectories(returns, initial_investment=10_000.0)
+>>> cumulative_yield = performance.yield_trajectories(returns) * 100.0
+>>> with TemporaryDirectory() as tmp:
+...     outdir = Path(tmp)
+...     Visualizer.line_chart(
+...         nav,
+...         title="NAV trajectories",
+...         ylabel="Portfolio value (USD)",
+...         save_path=str(outdir / "nav_curve.png"),
+...         show=False,
+...     )
+...     Visualizer.line_chart(
+...         cumulative_yield,
+...         title="Cumulative yield (%)",
+...         ylabel="Yield (%)",
+...         save_path=str(outdir / "yield_curve.png"),
+...         show=False,
+...     )
+```
+
 A steadily rising NAV indicates compounding growth; falling or flat lines flag underperformance.
 For a step-by-step example, see [docs/investor_walkthrough.md](docs/investor_walkthrough.md).
 

--- a/docs/investor_walkthrough.md
+++ b/docs/investor_walkthrough.md
@@ -15,39 +15,45 @@ This guide demonstrates how to evaluate a small set of stablecoin pools using th
 
 ## 2. Load sample performance data
 
-```python
-from pathlib import Path
-
-import pandas as pd
-
-from stable_yield_lab import Visualizer, performance
-
-
-# use bundled weekly returns
-yields_df = pd.read_csv("src/sample_yields.csv", parse_dates=["timestamp"])
-returns = yields_df.pivot(index="timestamp", columns="name", values="period_return")
-
-nav = performance.nav_curve(returns)
-yield_curve = performance.yield_curve(returns)
-
-artifact_dir = Path("artifacts")
-artifact_dir.mkdir(exist_ok=True)
-
-Visualizer.plot_nav(nav, save_path=str(artifact_dir / "nav_curve.png"), show=False)
-Visualizer.plot_yield(yield_curve, save_path=str(artifact_dir / "yield_curve.png"), show=False)
+```pycon
+>>> from pathlib import Path
+>>> from tempfile import TemporaryDirectory
+>>> import pandas as pd
+>>> from stable_yield_lab import Visualizer, performance
+>>>
+>>> yields_df = pd.read_csv("src/sample_yields.csv", parse_dates=["timestamp"])
+>>> returns = yields_df.pivot(index="timestamp", columns="name", values="period_return")
+>>> nav = performance.nav_trajectories(returns, initial_investment=10_000.0)
+>>> yield_pct = performance.yield_trajectories(returns) * 100.0
+>>> with TemporaryDirectory() as tmp:
+...     artifact_dir = Path(tmp)
+...     Visualizer.line_chart(
+...         nav,
+...         title="NAV trajectories",
+...         ylabel="Portfolio value (USD)",
+...         save_path=str(artifact_dir / "nav_curve.png"),
+...         show=False,
+...     )
+...     Visualizer.line_chart(
+...         yield_pct,
+...         title="Cumulative yield (%)",
+...         ylabel="Yield (%)",
+...         save_path=str(artifact_dir / "yield_curve.png"),
+...         show=False,
+...     )
 ```
 
-The `performance` module transforms the weekly return matrix into cumulative Net Asset Value and rolling yield series. `Visualizer.plot_nav` and `Visualizer.plot_yield` render the resulting curves and optionally export PNGs for reporting. Binary outputs are generated locally (and via CI artifacts) so no static charts are committed to the repository.
+The `performance` module transforms the weekly return matrix into Net Asset Value trajectories and cumulative yield series via `nav_trajectories` and `yield_trajectories`. `Visualizer.line_chart` renders both curves and optionally exports PNGs for reporting. Binary outputs are generated locally (and via CI artifacts) so no static charts are committed to the repository. Replace `TemporaryDirectory()` with a persistent `Path` if you want to keep the generated image assets between runs.
 
 ## 3. Interpret the charts
 
 ### Net Asset Value
 
-Inspect `artifacts/nav_curve.png` (or the interactive Matplotlib window if `show=True`). A steadily rising NAV indicates compounding growth across the selected pools, while drawdowns or flat stretches flag underperformance periods that merit a deeper dive into pool-specific events.
+Inspect the saved `nav_curve.png` (or the interactive Matplotlib window if `show=True`). A steadily rising NAV indicates compounding growth across the selected pools, while drawdowns or flat stretches flag underperformance periods that merit a deeper dive into pool-specific events.
 
 ### Weekly Yield
 
-Open `artifacts/yield_curve.png` to review the annualised yield profile. Yield spikes or drops highlight weeks where realised returns diverged from the long-run average—use them to annotate catalysts in investor updates or to stress-test assumptions.
+Open `yield_curve.png` from the same output directory to review the annualised yield profile. Yield spikes or drops highlight weeks where realised returns diverged from the long-run average—use them to annotate catalysts in investor updates or to stress-test assumptions.
 
 ## 4. Compare with riskfolio
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ strict = true
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-q --strict-markers"
+addopts = "-q --strict-markers --doctest-glob=README.md --doctest-glob=docs/*.md"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 filterwarnings = [


### PR DESCRIPTION
## Summary
- update README and investor walkthrough examples to use `nav_trajectories`, `yield_trajectories`, and `Visualizer.line_chart`
- clarify how to persist generated charts when running the walkthrough locally
- enable pytest doctest collection on README and docs to keep samples in sync

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9ae1173e8832faaab48109a20eecc