### PR TITLE
feat: add historical metrics to cross-section reporting

### DIFF
--- a/configs/demo.toml
+++ b/configs/demo.toml
@@ -16,8 +16,15 @@ stablecoins = []
 outdir = "docs"
 show = false
 charts = ["bar", "scatter", "chain"]
+history_charts = ["rolling_apy", "drawdowns", "realised_vs_target"]
 
 [reporting]
 top_n = 10
 perf_fee_bps = 0.0
 mgmt_fee_bps = 0.0
+
+[reporting.history]
+enabled = true
+rolling_windows = [4, 12]
+periods_per_year = 52
+target_field = "net_apy"

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -769,6 +769,36 @@ class Visualizer:
         if show:
             plt.show()
 
+    @staticmethod
+    def bar_realised_vs_target(
+        df: pd.DataFrame,
+        *,
+        title: str = "Realised vs target APY",
+        save_path: str | None = None,
+        show: bool = True,
+    ) -> None:
+        """Plot realised vs target APY as grouped bars in percentage space."""
+        if df.empty:
+            return
+        required = {"name", "realised_apy", "target_apy"}
+        if not required.issubset(df.columns):
+            raise ValueError("DataFrame must contain name, realised_apy and target_apy columns")
+        plt = Visualizer._plt()
+        plt.figure(figsize=(10, 6))
+        x = range(len(df))
+        width = 0.35
+        plt.bar(x, df["target_apy"] * 100.0, width=width, label="Target")
+        plt.bar([i + width for i in x], df["realised_apy"] * 100.0, width=width, label="Realised")
+        plt.xticks([i + width / 2 for i in x], df["name"], rotation=45, ha="right")
+        plt.ylabel("APY (%)")
+        plt.title(title)
+        plt.legend()
+        plt.tight_layout()
+        if save_path:
+            plt.savefig(save_path, bbox_inches="tight")
+        if show:
+            plt.show()
+
 
 # -----------------
 # Pipeline

--- a/tests/test_demo_config.py
+++ b/tests/test_demo_config.py
@@ -6,3 +6,7 @@ def test_loads_config_file() -> None:
     assert cfg["csv"]["path"].endswith("sample_pools.csv")
     assert cfg["output"]["show"] is False
     assert cfg["output"]["charts"] == ["bar", "scatter", "chain"]
+    assert cfg["output"]["history_charts"] == ["rolling_apy", "drawdowns", "realised_vs_target"]
+    history_cfg = cfg["reporting"]["history"]
+    assert history_cfg["enabled"] is True
+    assert history_cfg["rolling_windows"] == [4, 12]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stable_yield_lab import Pool, PoolRepository
+from stable_yield_lab.reporting import cross_section_report
+
+
+@pytest.mark.parametrize("with_returns", [False, True])
+def test_cross_section_report_history_outputs(tmp_path: Path, with_returns: bool) -> None:
+    repo = PoolRepository(
+        [
+            Pool(
+                name="PoolA",
+                chain="Ethereum",
+                stablecoin="USDC",
+                tvl_usd=1_000_000,
+                base_apy=0.03,
+                timestamp=1_700_000_000,
+            ),
+            Pool(
+                name="PoolB",
+                chain="Ethereum",
+                stablecoin="DAI",
+                tvl_usd=500_000,
+                base_apy=0.02,
+                timestamp=1_700_000_000,
+            ),
+        ]
+    )
+
+    returns = pd.DataFrame(
+        {
+            "PoolA": [0.01, 0.02, 0.015],
+            "PoolB": [0.005, -0.002, 0.01],
+        },
+        index=pd.to_datetime(["2024-01-01", "2024-01-08", "2024-01-15"], utc=True),
+    )
+
+    history_kwargs = {
+        "returns": returns if with_returns else None,
+        "rolling_windows": (2,),
+        "periods_per_year": 2,
+    }
+
+    paths = cross_section_report(
+        repo,
+        tmp_path,
+        perf_fee_bps=0.0,
+        mgmt_fee_bps=0.0,
+        top_n=2,
+        **history_kwargs,
+    )
+
+    base_keys = {"pools", "by_chain", "by_source", "by_stablecoin", "topN", "concentration"}
+    assert base_keys.issubset(paths)
+
+    if not with_returns:
+        assert {"rolling_apy", "drawdowns", "drawdown_summary", "realised_vs_target"}.isdisjoint(paths)
+        return
+
+    # Rolling APY CSV
+    rolling_df = pd.read_csv(paths["rolling_apy"], parse_dates=["timestamp"])
+    assert sorted(rolling_df["window"].unique()) == [2]
+    mask = (
+        (rolling_df["name"] == "PoolA")
+        & (rolling_df["window"] == 2)
+        & (rolling_df["timestamp"] == pd.Timestamp("2024-01-08", tz="UTC"))
+    )
+    value = float(rolling_df.loc[mask, "rolling_apy"].iloc[0])
+    expected_pool_a = ((1 + 0.01) * (1 + 0.02)) ** (2 / 2) - 1
+    assert value == pytest.approx(expected_pool_a)
+
+    # Drawdown time-series and summary
+    drawdowns = pd.read_csv(paths["drawdowns"], parse_dates=["timestamp"])
+    pool_b_dd = drawdowns[
+        (drawdowns["name"] == "PoolB") & (drawdowns["timestamp"] == pd.Timestamp("2024-01-08", tz="UTC"))
+    ]["drawdown"].iloc[0]
+    expected_drawdown = (1 + 0.005) * (1 - 0.002) / (1 + 0.005) - 1
+    assert pool_b_dd == pytest.approx(expected_drawdown)
+
+    summary = pd.read_csv(paths["drawdown_summary"])
+    pool_b_summary = summary[summary["name"] == "PoolB"].iloc[0]
+    assert pool_b_summary["max_drawdown"] == pytest.approx(expected_drawdown)
+
+    # Realised vs target APY comparison
+    realised = pd.read_csv(paths["realised_vs_target"])
+    pool_a_realised = realised[realised["name"] == "PoolA"].iloc[0]
+    realised_expected = (1 + returns["PoolA"].mean()) ** 2 - 1
+    assert pool_a_realised["realised_apy"] == pytest.approx(realised_expected)
+    assert pool_a_realised["target_apy"] == pytest.approx(0.03)
+    assert pool_a_realised["realised_minus_target"] == pytest.approx(
+        realised_expected - 0.03
+    )


### PR DESCRIPTION
## Summary
- extend cross_section_report to derive rolling APYs, drawdowns, and realised vs target comparisons from historical returns
- wire CLI configuration to persist the new CSV outputs and generate plots guarded by reproducibility flags
- cover reporting changes with targeted pytest fixtures and update the demo config defaults

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c9ae13b93c832f882c0e073221345c