### PR TITLE
Add schema-aware CSV ingestion and config controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ The script applies `stable_yield_lab.performance.nav_curve` and `performance.yie
 A steadily rising NAV indicates compounding growth; falling or flat lines flag underperformance.
 For a step-by-step example, see [docs/investor_walkthrough.md](docs/investor_walkthrough.md).
 
+### Demo configuration
+
+Configuration values are supplied via TOML. The `[csv]` section controls the
+validated ingestion layer that powers the CLI demo:
+
+| Key | Description |
+| --- | --- |
+| `path` | Path to the cached CSV of pools. |
+| `validation` | One of `"none"`, `"warn"`, or `"strict"` to control schema enforcement. |
+| `expected_frequency` | Optional pandas-style frequency string (`"D"`, `"W"`, etc.) checked against inferred cadence. |
+| `auto_refresh` | When `true`, call the refresh hook before reading cached data. |
+| `refresh_url` | Optional HTTP endpoint that returns the latest CSV; used when `auto_refresh = true`. |
+
+When `auto_refresh` is enabled but no `refresh_url` is provided the demo skips
+the refresh and logs a warning. Successful ingestion prints the detected
+frequency whenever the timestamp column contains enough information to infer
+periodicity.
+
 ## Codex Workflows
 
 GitHub workflows tag [@codex](https://github.com/features/copilot) to request automated pull request reviews,

--- a/configs/demo.toml
+++ b/configs/demo.toml
@@ -4,6 +4,10 @@ yields_csv = "src/sample_yields.csv"
 
 [csv]
 path = "src/sample_pools.csv"
+validation = "warn"
+expected_frequency = ""
+auto_refresh = false
+refresh_url = ""
 
 [filters]
 min_tvl = 100000

--- a/src/stable_yield_demo.py
+++ b/src/stable_yield_demo.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import tomllib
+import urllib.request
 from pathlib import Path
 from typing import Any, cast
 
 from stable_yield_lab import (
-    CSVSource,
     HistoricalCSVSource,
     Metrics,
     Pipeline,
+    SchemaAwareCSVSource,
     Visualizer,
     performance,
     risk_metrics,
 )
 from stable_yield_lab.reporting import cross_section_report
+
+
+logger = logging.getLogger(__name__)
 
 
 def load_config(path: str | Path | None) -> dict[str, Any]:
@@ -34,7 +39,13 @@ def load_config(path: str | Path | None) -> dict[str, Any]:
     """
 
     default = {
-        "csv": {"path": str(Path(__file__).with_name("sample_pools.csv"))},
+        "csv": {
+            "path": str(Path(__file__).with_name("sample_pools.csv")),
+            "validation": "warn",
+            "expected_frequency": None,
+            "auto_refresh": False,
+            "refresh_url": None,
+        },
         "yields_csv": str(Path(__file__).with_name("sample_yields.csv")),
         "initial_investment": 1_000.0,
         "filters": {
@@ -92,9 +103,42 @@ def main() -> None:
             pass
 
     # Load data
-    csv_path = cfg["csv"]["path"]
-    src = CSVSource(path=csv_path)
+    csv_cfg = cfg.get("csv", {})
+    csv_path = str(csv_cfg.get("path", cfg["csv"]["path"]))
+    validation_level = str(csv_cfg.get("validation", "warn"))
+    expected_frequency = csv_cfg.get("expected_frequency")
+    if expected_frequency:
+        expected_frequency = str(expected_frequency)
+    else:
+        expected_frequency = None
+    frequency_column = str(csv_cfg.get("frequency_column", "timestamp"))
+    auto_refresh = bool(csv_cfg.get("auto_refresh", False))
+    refresh_url = csv_cfg.get("refresh_url") or None
+
+    refresh_callback = None
+    if refresh_url:
+        url = str(refresh_url)
+
+        def refresh_callback(target: Path, *, _url: str = url) -> None:
+            with urllib.request.urlopen(_url) as response:
+                target.write_bytes(response.read())
+
+    elif auto_refresh:
+        logger.warning("Auto refresh requested but no refresh_url provided; skipping refresh.")
+        auto_refresh = False
+
+    src = SchemaAwareCSVSource(
+        path=csv_path,
+        validation=validation_level,
+        expected_frequency=expected_frequency,
+        frequency_column=frequency_column,
+        auto_refresh=auto_refresh,
+        refresh_callback=refresh_callback,
+    )
     repo = Pipeline([src]).run()
+
+    if src.detected_frequency:
+        print(f"Detected CSV frequency: {src.detected_frequency}")
 
     # Apply filters
     f = cfg.get("filters", {})

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -15,7 +15,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Callable, Mapping, Protocol, Literal, cast
 import json
 import logging
 import urllib.request
@@ -175,6 +175,255 @@ class CSVSource:
         return pools
 
 
+class SchemaAwareCSVSource(CSVSource):
+    """CSV loader with schema validation, frequency inference and refresh hooks."""
+
+    DEFAULT_SCHEMA: Mapping[str, Any] = {
+        "name": str,
+        "chain": str,
+        "stablecoin": str,
+        "tvl_usd": float,
+        "base_apy": float,
+        "reward_apy": float,
+        "is_auto": bool,
+        "source": str,
+        "risk_score": float,
+        "timestamp": float,
+    }
+
+    def __init__(
+        self,
+        path: str | Path,
+        schema: Mapping[str, Any] | None = None,
+        *,
+        validation: ValidationLevel = "warn",
+        expected_frequency: str | None = None,
+        frequency_column: str = "timestamp",
+        auto_refresh: bool = False,
+        refresh_callback: Callable[[Path], None] | None = None,
+    ) -> None:
+        super().__init__(str(path))
+        self.path_obj = Path(path)
+        base_schema = dict(self.DEFAULT_SCHEMA)
+        if schema:
+            base_schema.update(schema)
+        self.schema = base_schema
+        level = str(validation).lower()
+        if level not in {"none", "warn", "strict"}:
+            raise ValueError(f"Unknown validation level: {validation}")
+        self.validation: ValidationLevel = cast(ValidationLevel, level)
+        self.expected_frequency = expected_frequency or None
+        self.frequency_column = frequency_column
+        self.auto_refresh = bool(auto_refresh)
+        self.refresh_callback = refresh_callback
+        self.detected_frequency: str | None = None
+
+    def fetch(self) -> list[Pool]:
+        self._maybe_refresh()
+        df = pd.read_csv(self.path_obj)
+        self._validate_columns(df)
+        for column, expected in self.schema.items():
+            if column in df.columns:
+                self._convert_column(df, column, expected)
+
+        self.detected_frequency = None
+        if self.frequency_column in df.columns:
+            freq = self._infer_frequency(df[self.frequency_column])
+            self.detected_frequency = freq
+            if self.expected_frequency:
+                if freq is None:
+                    self._handle_validation_issue(
+                        (
+                            f"Unable to infer frequency for column '{self.frequency_column}' "
+                            f"(expected {self.expected_frequency})."
+                        )
+                    )
+                elif freq != self.expected_frequency:
+                    self._handle_validation_issue(
+                        (
+                            f"Detected frequency '{freq}' does not match expected "
+                            f"'{self.expected_frequency}'."
+                        )
+                    )
+
+        now = datetime.now(tz=UTC).timestamp()
+        pools: list[Pool] = []
+        for _, row in df.iterrows():
+            pools.append(
+                Pool(
+                    name=self._as_str(row.get("name"), ""),
+                    chain=self._as_str(row.get("chain"), ""),
+                    stablecoin=self._as_str(row.get("stablecoin"), ""),
+                    tvl_usd=self._as_float(row.get("tvl_usd"), 0.0),
+                    base_apy=self._as_float(row.get("base_apy"), 0.0),
+                    reward_apy=self._as_float(row.get("reward_apy"), 0.0),
+                    is_auto=self._as_bool(row.get("is_auto"), True),
+                    source=self._as_str(row.get("source"), "csv"),
+                    risk_score=self._as_float(row.get("risk_score"), 2.0),
+                    timestamp=self._timestamp_from_value(row.get("timestamp"), now),
+                )
+            )
+        return pools
+
+    def _maybe_refresh(self) -> None:
+        if not (self.auto_refresh and self.refresh_callback):
+            return
+        try:
+            self.refresh_callback(self.path_obj)
+        except Exception as exc:
+            message = f"Refresh callback failed for {self.path_obj}: {exc}"
+            if self.validation == "strict":
+                raise RuntimeError(message) from exc
+            logger.warning(message)
+
+    def _validate_columns(self, df: pd.DataFrame) -> None:
+        missing = [col for col in self.schema if col not in df.columns]
+        if missing:
+            self._handle_validation_issue(
+                f"CSV missing expected columns: {', '.join(missing)}"
+            )
+            for col in missing:
+                if col not in df.columns:
+                    df[col] = pd.NA
+
+    def _convert_column(self, df: pd.DataFrame, column: str, expected: Any) -> None:
+        series = df[column]
+        if expected in {float, int}:
+            converted = pd.to_numeric(series, errors="coerce")
+            invalid_mask = converted.isna() & ~series.isna()
+            if invalid_mask.any():
+                self._handle_validation_issue(
+                    f"Column '{column}' contains non-numeric values; coerced to NaN."
+                )
+            if expected is int:
+                converted = converted.round().astype("Int64")
+            df[column] = converted
+            return
+        if expected is bool:
+            converted_values: list[bool] = []
+            had_errors = False
+            for value in series:
+                try:
+                    converted_values.append(self._convert_bool(value))
+                except ValueError:
+                    had_errors = True
+                    converted_values.append(True)
+            if had_errors:
+                self._handle_validation_issue(
+                    f"Column '{column}' contains invalid booleans; defaulting to True."
+                )
+            df[column] = pd.Series(converted_values, dtype=bool)
+            return
+        if expected is str:
+            df[column] = series.astype(str)
+            return
+        if callable(expected):
+            try:
+                df[column] = series.apply(expected)
+            except Exception as exc:
+                self._handle_validation_issue(
+                    f"Failed to apply converter for column '{column}': {exc}", exc
+                )
+            return
+
+    def _infer_frequency(self, series: pd.Series) -> str | None:
+        if series.empty:
+            return None
+        if pd.api.types.is_datetime64_any_dtype(series):
+            dt_series = series.dropna()
+        elif pd.api.types.is_numeric_dtype(series):
+            dt_series = pd.to_datetime(series, unit="s", utc=True, errors="coerce").dropna()
+        else:
+            dt_series = pd.to_datetime(series, utc=True, errors="coerce").dropna()
+        if dt_series.empty:
+            return None
+        index = pd.DatetimeIndex(dt_series.sort_values().unique())
+        if len(index) < 3:
+            return None
+        try:
+            freq = pd.infer_freq(index)
+        except (TypeError, ValueError):
+            return None
+        if freq is None:
+            return None
+        try:
+            alias = pd.tseries.frequencies.to_offset(freq).freqstr
+        except ValueError:
+            alias = freq
+        return cast(str | None, alias)
+
+    def _handle_validation_issue(self, message: str, exc: Exception | None = None) -> None:
+        if self.validation == "strict":
+            raise ValueError(message) from exc
+        if self.validation == "warn":
+            logger.warning(message)
+
+    @staticmethod
+    def _convert_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if pd.isna(value):
+            raise ValueError("Boolean value is missing")
+        if isinstance(value, (int, float)):
+            return bool(int(value))
+        if isinstance(value, str):
+            val = value.strip().lower()
+            if val in {"true", "1", "yes", "y", "t"}:
+                return True
+            if val in {"false", "0", "no", "n", "f"}:
+                return False
+        raise ValueError(f"Cannot interpret boolean value {value!r}")
+
+    @staticmethod
+    def _as_str(value: Any, default: str) -> str:
+        if pd.isna(value):
+            return default
+        return str(value)
+
+    @staticmethod
+    def _as_float(value: Any, default: float) -> float:
+        if pd.isna(value):
+            return float(default)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return float(default)
+
+    def _as_bool(self, value: Any, default: bool) -> bool:
+        if pd.isna(value):
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(int(value))
+        if isinstance(value, str):
+            val = value.strip().lower()
+            if val in {"true", "1", "yes", "y", "t"}:
+                return True
+            if val in {"false", "0", "no", "n", "f"}:
+                return False
+        return default
+
+    def _timestamp_from_value(self, value: Any, default: float) -> float:
+        if pd.isna(value):
+            return default
+        if isinstance(value, pd.Timestamp):
+            return value.to_pydatetime().timestamp()
+        if isinstance(value, datetime):
+            dt = value if value.tzinfo else value.replace(tzinfo=UTC)
+            return dt.timestamp()
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            parsed = pd.to_datetime(value, utc=True, errors="coerce")
+            if pd.isna(parsed):
+                self._handle_validation_issue(
+                    f"Unable to parse timestamp value {value!r}; using fallback."
+                )
+                return default
+            return parsed.to_pydatetime().timestamp()
+
+
 class HistoricalCSVSource:
     """Load periodic returns from a CSV with timestamp, name and period_return."""
 
@@ -200,6 +449,8 @@ class HistoricalCSVSource:
 
 
 logger = logging.getLogger(__name__)
+
+ValidationLevel = Literal["none", "warn", "strict"]
 
 STABLE_TOKENS = {
     "USDC",

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,10 +1,16 @@
+from __future__ import annotations
+
 from pathlib import Path
+
+import pandas as pd
+import pytest
 
 from stable_yield_lab import (
     BeefySource,
     DefiLlamaSource,
     MorphoSource,
     PoolRepository,
+    SchemaAwareCSVSource,
 )
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
@@ -44,3 +50,80 @@ def test_filter_auto_only_mixed_sources() -> None:
     auto = repo.filter(auto_only=True)
     assert all(p.is_auto for p in auto)
     assert all(p.source == "beefy" for p in auto)
+
+
+def test_schema_validation_strict_raises(tmp_path: Path) -> None:
+    csv_path = tmp_path / "invalid.csv"
+    csv_path.write_text(
+        """name,chain,stablecoin,tvl_usd,base_apy,reward_apy,is_auto,source,risk_score,timestamp
+Invalid Pool,Ethereum,USDC,not_a_number,0.05,0.0,True,UnitTest,2.0,1700000000
+"""
+    )
+
+    src = SchemaAwareCSVSource(path=str(csv_path), validation="strict")
+    with pytest.raises(ValueError) as exc:
+        src.fetch()
+
+    assert "tvl_usd" in str(exc.value)
+
+
+def test_schema_frequency_inference(tmp_path: Path) -> None:
+    timestamps = pd.date_range("2024-01-01", periods=4, freq="D").astype("int64") // 10**9
+    df = pd.DataFrame(
+        {
+            "name": [f"Pool {i}" for i in range(4)],
+            "chain": ["Ethereum"] * 4,
+            "stablecoin": ["USDC"] * 4,
+            "tvl_usd": [1_000_000.0] * 4,
+            "base_apy": [0.05] * 4,
+            "reward_apy": [0.0] * 4,
+            "is_auto": [True] * 4,
+            "source": ["UnitTest"] * 4,
+            "risk_score": [2.0] * 4,
+            "timestamp": timestamps,
+        }
+    )
+    csv_path = tmp_path / "freq.csv"
+    df.to_csv(csv_path, index=False)
+
+    src = SchemaAwareCSVSource(path=str(csv_path), expected_frequency="D", validation="strict")
+    pools = src.fetch()
+
+    assert len(pools) == 4
+    assert src.detected_frequency == "D"
+
+
+def test_schema_auto_refresh(tmp_path: Path) -> None:
+    csv_path = tmp_path / "refresh.csv"
+    csv_path.write_text(
+        """name,chain,stablecoin,tvl_usd,base_apy,reward_apy,is_auto,source,risk_score,timestamp
+Stale,Ethereum,USDC,1000000,0.05,0.0,True,Cache,2.0,1700000000
+"""
+    )
+
+    def refresh_callback(target: Path) -> None:
+        updated = pd.DataFrame(
+            {
+                "name": ["Fresh"],
+                "chain": ["Ethereum"],
+                "stablecoin": ["USDC"],
+                "tvl_usd": [2_000_000.0],
+                "base_apy": [0.08],
+                "reward_apy": [0.0],
+                "is_auto": [True],
+                "source": ["API"],
+                "risk_score": [2.0],
+                "timestamp": [1700000000],
+            }
+        )
+        updated.to_csv(target, index=False)
+
+    src = SchemaAwareCSVSource(
+        path=str(csv_path),
+        auto_refresh=True,
+        refresh_callback=refresh_callback,
+    )
+    pools = src.fetch()
+
+    assert len(pools) == 1
+    assert pools[0].name == "Fresh"


### PR DESCRIPTION
## Summary
- add `SchemaAwareCSVSource` with schema validation, frequency inference, and optional refresh callbacks
- update the CLI demo and config template to expose validation level, expected cadence, and auto-refresh toggles
- document the new configuration keys and cover schema/frequency behaviour with focused tests

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c9ae03ec4c832f8307328974872837