### PR TITLE
feat: add return distribution visualizations

### DIFF
--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -43,3 +43,35 @@ def test_line_nav_creates_file(tmp_path: Path) -> None:
     out = tmp_path / "nav.png"
     Visualizer.line_nav(nav, save_path=str(out), show=False)
     assert out.exists() and out.stat().st_size > 0
+
+
+def test_hist_period_returns_creates_file(tmp_path: Path) -> None:
+    returns = pd.DataFrame(
+        {
+            "PoolA": [0.01, 0.015, -0.005, 0.012],
+            "PoolB": [0.008, 0.01, 0.011, 0.009],
+        },
+        index=pd.date_range("2023-01-01", periods=4, freq="W"),
+    )
+    out = tmp_path / "hist_returns.png"
+    Visualizer.hist_period_returns(returns, bins=5, save_path=str(out), show=False)
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_boxplot_rolling_apy_creates_file(tmp_path: Path) -> None:
+    returns = pd.DataFrame(
+        {
+            "PoolA": [0.01, 0.012, -0.004, 0.015, 0.009],
+            "PoolB": [0.008, 0.007, 0.01, 0.011, 0.012],
+        },
+        index=pd.date_range("2023-01-01", periods=5, freq="W"),
+    )
+    out = tmp_path / "rolling_apy_box.png"
+    Visualizer.boxplot_rolling_apy(
+        returns,
+        window=3,
+        periods_per_year=52,
+        save_path=str(out),
+        show=False,
+    )
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add histogram and rolling APY box-plot helpers to the visualizer for period returns analysis
- expose the new charts through CLI configuration and cross-section reporting toggles with disk export support
- cover the new plotting utilities with regression tests

## Testing
- poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9ae365cc0832fb567c9835e9a13d3