### PR TITLE
feat: add NAV benchmark overlays

### DIFF
--- a/configs/demo.toml
+++ b/configs/demo.toml
@@ -21,3 +21,12 @@ charts = ["bar", "scatter", "chain"]
 top_n = 10
 perf_fee_bps = 0.0
 mgmt_fee_bps = 0.0
+
+[benchmarks]
+tickers = ["PoolA", "PoolB"]
+cash_rate = 0.0
+
+[benchmarks.labels]
+rebalance = "Equal-weight Rebalanced"
+buy_and_hold = "Buy & Hold"
+cash = "Cash (0%)"

--- a/tests/test_demo_config.py
+++ b/tests/test_demo_config.py
@@ -6,3 +6,5 @@ def test_loads_config_file() -> None:
     assert cfg["csv"]["path"].endswith("sample_pools.csv")
     assert cfg["output"]["show"] is False
     assert cfg["output"]["charts"] == ["bar", "scatter", "chain"]
+    assert cfg["benchmarks"]["tickers"] == ["PoolA", "PoolB"]
+    assert cfg["benchmarks"]["labels"]["cash"].startswith("Cash")


### PR DESCRIPTION
## Summary
- add deep config merging with benchmark defaults for the demo CLI
- extend the visualizer with a NAV vs benchmark overlay helper and accompanying tests
- generate configurable benchmark outputs (chart + CSV) in the CLI using returns-derived series

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c9ae368b34832f88317fe5200b9a47