### PR TITLE
Add regression fixtures for two-asset rebalances

### DIFF
--- a/tests/fixtures/portfolio/two_asset_missing_rebalance.json
+++ b/tests/fixtures/portfolio/two_asset_missing_rebalance.json
@@ -1,0 +1,13 @@
+{
+  "description": "Attempted rebalance into an asset without return history, expected to fail because the weights collapse to zero after alignment.",
+  "initial_nav": 1.0,
+  "returns": [
+    {"date": "2024-02-05", "AssetA": 0.01, "AssetB": 0.02},
+    {"date": "2024-02-12", "AssetA": -0.015, "AssetB": 0.005},
+    {"date": "2024-02-19", "AssetA": 0.0, "AssetB": 0.0}
+  ],
+  "schedule": [
+    {"date": "2024-02-05", "weights": {"AssetA": 0.5, "AssetB": 0.5}},
+    {"date": "2024-02-19", "weights": {"MissingAsset": 1.0}}
+  ]
+}

--- a/tests/fixtures/portfolio/two_asset_weekly_rebalances.json
+++ b/tests/fixtures/portfolio/two_asset_weekly_rebalances.json
@@ -1,0 +1,26 @@
+{
+  "description": "Five weekly observations for a two-asset portfolio rebalance from 70/30 to 0/100 with missing returns treated as flat performance.",
+  "initial_nav": 1.0,
+  "returns": [
+    {"date": "2024-01-01", "AssetA": 0.01, "AssetB": 0.005},
+    {"date": "2024-01-08", "AssetA": 0.015, "AssetB": null},
+    {"date": "2024-01-15", "AssetA": -0.02, "AssetB": 0.012},
+    {"date": "2024-01-22", "AssetA": null, "AssetB": 0.01},
+    {"date": "2024-01-29", "AssetA": 0.0, "AssetB": -0.005}
+  ],
+  "schedule": [
+    {"date": "2024-01-01", "weights": {"AssetA": 0.7, "AssetB": 0.3}},
+    {"date": "2024-01-22", "weights": {"AssetA": 0.0, "AssetB": 1.0}}
+  ],
+  "expected_nav": [
+    {"date": "2024-01-01", "nav": 1.0085},
+    {"date": "2024-01-08", "nav": 1.01908925},
+    {"date": "2024-01-15", "nav": 1.0084907218},
+    {"date": "2024-01-22", "nav": 1.018575629018},
+    {"date": "2024-01-29", "nav": 1.0134827508729098}
+  ],
+  "expected_apy": {
+    "2024-01-01": 0.22919179921493785,
+    "2024-01-22": 0.13864364655315664
+  }
+}

--- a/tests/test_portfolio_rebalances.py
+++ b/tests/test_portfolio_rebalances.py
@@ -1,0 +1,111 @@
+"""Regression fixtures for portfolio rebalances with deterministic outcomes.
+
+The JSON fixtures under ``tests/fixtures/portfolio`` provide hand-crafted
+two-asset return paths and rebalance instructions so contributors can validate
+NAV and APY calculations:
+
+* ``two_asset_weekly_rebalances.json`` contains five weekly observations. The
+  portfolio begins at a 70%/30% split, rebalances to a 0%/100% allocation on the
+  fourth timestamp, and includes missing return values that should be interpreted
+  as flat performance. Expected NAV levels and APY results for each rebalance are
+  embedded in the fixture for regression checks.
+* ``two_asset_missing_rebalance.json`` describes a scenario where the schedule
+  attempts to shift entirely into an asset without price history. When the
+  rebalance date arrives the weights collapse to zero after alignment with the
+  available return columns, so the implementation should raise ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stable_yield_lab.performance import nav_series
+from stable_yield_lab import portfolio
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "portfolio"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    with (_FIXTURE_DIR / name).open() as handle:
+        return json.load(handle)
+
+
+def _returns_from_fixture(raw_returns: Iterable[dict[str, object]]) -> pd.DataFrame:
+    frame = pd.DataFrame(raw_returns)
+    index = pd.to_datetime(frame.pop("date"), utc=True)
+    return frame.astype(float).set_index(index)
+
+
+def _schedule_from_fixture(raw_schedule: Iterable[dict[str, object]]) -> list[tuple[pd.Timestamp, pd.Series]]:
+    schedule: list[tuple[pd.Timestamp, pd.Series]] = []
+    for entry in raw_schedule:
+        ts = pd.Timestamp(entry["date"], tz="UTC")
+        weights = pd.Series(entry["weights"], dtype=float)
+        schedule.append((ts, weights))
+    return sorted(schedule, key=lambda item: item[0])
+
+
+def _simulate_nav_with_schedule(
+    returns: pd.DataFrame, schedule: list[tuple[pd.Timestamp, pd.Series]], initial: float
+) -> pd.Series:
+    if not schedule:
+        raise ValueError("rebalance schedule is empty")
+
+    returns = returns.sort_index()
+    nav_paths: list[pd.Series] = []
+    current_nav = float(initial)
+
+    for idx, (start, weights) in enumerate(schedule):
+        if idx + 1 < len(schedule):
+            next_start = schedule[idx + 1][0]
+            mask = (returns.index >= start) & (returns.index < next_start)
+        else:
+            mask = returns.index >= start
+        segment = returns.loc[mask]
+        if segment.empty:
+            raise ValueError(f"no return observations available for rebalance at {start.isoformat()}")
+        nav_segment = nav_series(segment, weights, initial=current_nav)
+        nav_paths.append(nav_segment)
+        current_nav = float(nav_segment.iloc[-1])
+
+    combined = pd.concat(nav_paths)
+    return combined[~combined.index.duplicated(keep="last")]
+
+
+def test_weekly_rebalances_nav_and_apy_regressions() -> None:
+    fixture = _load_fixture("two_asset_weekly_rebalances.json")
+    returns = _returns_from_fixture(fixture["returns"])
+    schedule = _schedule_from_fixture(fixture["schedule"])
+    nav = _simulate_nav_with_schedule(returns, schedule, float(fixture["initial_nav"]))
+
+    expected_nav = pd.Series(
+        data=[item["nav"] for item in fixture["expected_nav"]],
+        index=pd.to_datetime([item["date"] for item in fixture["expected_nav"]], utc=True),
+    )
+    pd.testing.assert_series_equal(nav, expected_nav, rtol=1e-12, atol=0.0, check_names=False)
+
+    expected_apy_map = fixture["expected_apy"]
+    for idx, (start, weights) in enumerate(schedule):
+        if idx + 1 < len(schedule):
+            next_start = schedule[idx + 1][0]
+            mask = (returns.index >= start) & (returns.index < next_start)
+        else:
+            mask = returns.index >= start
+        segment = returns.loc[mask]
+        apy = portfolio.expected_apy(segment, weights)
+        key = start.strftime("%Y-%m-%d")
+        assert apy == pytest.approx(float(expected_apy_map[key]))
+
+
+def test_missing_asset_rebalance_raises_value_error() -> None:
+    fixture = _load_fixture("two_asset_missing_rebalance.json")
+    returns = _returns_from_fixture(fixture["returns"])
+    schedule = _schedule_from_fixture(fixture["schedule"])
+
+    with pytest.raises(ValueError, match="weights sum to zero"):
+        _simulate_nav_with_schedule(returns, schedule, float(fixture["initial_nav"]))


### PR DESCRIPTION
## Summary
- add two deterministic two-asset rebalance fixtures covering zero-weight and missing-return periods
- add regression tests that replay the schedules to assert NAV paths and expected APY values
- verify the library raises a ValueError when a scheduled rebalance targets an asset without data

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ae8a7cd4832f9495e1926a806098