### PR TITLE
Merge PRs #44 and #45 into work resolution branch

### DIFF
--- a/src/stable_yield_lab/portfolio.py
+++ b/src/stable_yield_lab/portfolio.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
 import pandas as pd
 
 from .risk_metrics import _require_riskfolio
@@ -63,3 +67,317 @@ def tvl_weighted_risk(returns: pd.DataFrame, weights: pd.Series, *, rm: str = "M
     cov = returns.cov()
     rc = rp.Risk_Contribution(weights, returns, cov, rm=rm)
     return float(rc.sum())
+
+
+@dataclass(frozen=True)
+class RebalanceResult:
+    """Container for the outputs of :func:`rebalance_portfolio`.
+
+    Attributes
+    ----------
+    weights:
+        DataFrame with the same index as the input returns and columns for every
+        asset encountered across the simulation. Each row represents the
+        portfolio weights applied at the beginning of that period after
+        rebalancing and normalising for asset availability.
+    portfolio_returns:
+        Period-by-period portfolio returns obtained by compounding the asset
+        level returns with the simulated weights.
+    nav:
+        Net Asset Value path assuming an initial NAV of 1.0 by default.
+    """
+
+    weights: pd.DataFrame
+    portfolio_returns: pd.Series
+    nav: pd.Series
+
+
+def _ensure_datetime_index(index: Sequence[pd.Timestamp | str] | pd.Index) -> pd.DatetimeIndex:
+    if isinstance(index, pd.DatetimeIndex):
+        return index.tz_convert("UTC") if index.tz is not None else index.tz_localize("UTC")
+    converted = pd.to_datetime(list(index), utc=True)
+    return pd.DatetimeIndex(converted)
+
+
+def _to_utc_timestamp(value: pd.Timestamp | str) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        return ts.tz_localize("UTC")
+    return ts.tz_convert("UTC")
+
+
+def _as_weight_series(weights: Mapping[str, float] | pd.Series) -> pd.Series:
+    if isinstance(weights, pd.Series):
+        series = weights.astype(float).copy()
+    elif isinstance(weights, Mapping):
+        series = pd.Series(dict(weights), dtype=float)
+    else:
+        raise TypeError("Weights must be provided as a mapping or pandas Series.")
+    series = series.reindex(sorted(series.index)).fillna(0.0)
+    return series
+
+
+def _normalise_row(row: pd.Series) -> pd.Series:
+    row = row.fillna(0.0)
+    total = row.sum()
+    if pd.isna(total) or total <= 0:
+        return row * 0.0
+    return row / total
+
+
+def _normalise_frame_rows(frame: pd.DataFrame) -> pd.DataFrame:
+    normalised = frame.copy()
+    for idx, row in normalised.iterrows():
+        normalised.loc[idx] = _normalise_row(row)
+    return normalised.fillna(0.0)
+
+
+def _resolve_target_frame(
+    schedule: pd.DatetimeIndex,
+    target_weights: (
+        pd.DataFrame
+        | Mapping[Any, Mapping[str, float] | pd.Series]
+        | Callable[[pd.Timestamp], Mapping[str, float] | pd.Series]
+    ),
+) -> pd.DataFrame:
+    if isinstance(target_weights, pd.DataFrame):
+        frame = target_weights.copy()
+        frame.index = _ensure_datetime_index(frame.index)
+        missing = schedule.difference(frame.index)
+        if not missing.empty:
+            raise KeyError(f"Missing target weights for rebalance dates: {missing.tolist()}")
+        frame = frame.reindex(schedule)
+        frame = frame.fillna(0.0)
+        return _normalise_frame_rows(frame)
+
+    rows: list[pd.Series] = []
+    columns: set[str] = set()
+
+    if isinstance(target_weights, Mapping):
+        keyed: dict[pd.Timestamp, pd.Series] = {}
+        for key, value in target_weights.items():
+            ts = _to_utc_timestamp(key)
+            keyed[ts] = _as_weight_series(value)
+            columns.update(keyed[ts].index.tolist())
+        missing = schedule.difference(pd.DatetimeIndex(keyed.keys()))
+        if not missing.empty:
+            raise KeyError(f"Missing target weights for rebalance dates: {missing.tolist()}")
+        for ts in schedule:
+            row = keyed[ts].reindex(sorted(columns)).fillna(0.0)
+            rows.append(row)
+    elif callable(target_weights):
+        for ts in schedule:
+            row = _as_weight_series(target_weights(ts))
+            columns.update(row.index.tolist())
+            rows.append(row)
+        rows = [row.reindex(sorted(columns)).fillna(0.0) for row in rows]
+    else:
+        raise TypeError(
+            "target_weights must be a DataFrame, mapping keyed by rebalance date, or callable returning weights."
+        )
+
+    if not rows:
+        raise ValueError("No target weights produced for the provided schedule.")
+
+    frame = pd.DataFrame(rows, index=schedule)
+    frame = frame.fillna(0.0)
+    return _normalise_frame_rows(frame)
+
+
+def rebalance_portfolio(
+    returns: pd.DataFrame,
+    *,
+    rebalance_schedule: Sequence[pd.Timestamp | str] | pd.Index,
+    target_weights: (
+        pd.DataFrame
+        | Mapping[Any, Mapping[str, float] | pd.Series]
+        | Callable[[pd.Timestamp], Mapping[str, float] | pd.Series]
+    ),
+    initial_weights: Mapping[str, float] | pd.Series | None = None,
+    initial_nav: float = 1.0,
+) -> RebalanceResult:
+    """Simulate a rebalancing strategy over a returns panel.
+
+    Parameters
+    ----------
+    returns:
+        Asset return panel (index = timestamps, columns = assets). Values are
+        simple periodic returns (e.g. weekly growth rates). Missing values denote
+        an asset being unavailable that period.
+    rebalance_schedule:
+        Iterable of timestamps where the portfolio is rebalanced to target
+        weights. The timestamps must exist in ``returns.index`` once normalised
+        to UTC.
+    target_weights:
+        Target weights provided either as a DataFrame keyed by rebalance date, a
+        mapping from rebalance date to weights, or a callable returning weights
+        for each rebalance date. The callable is invoked with a
+        :class:`pandas.Timestamp` and must return a mapping or Series of weights.
+    initial_weights:
+        Optional starting weights used prior to the first rebalance event. If
+        omitted the first rebalance defines the initial allocation. When
+        provided they are normalised to sum to one across available assets.
+    initial_nav:
+        Starting net asset value used to compound portfolio returns.
+    """
+
+    if returns.empty:
+        raise ValueError("returns DataFrame must not be empty.")
+
+    returns = returns.copy()
+    returns.index = _ensure_datetime_index(returns.index)
+    returns = returns.sort_index()
+
+    schedule = _ensure_datetime_index(rebalance_schedule)
+    schedule = schedule.sort_values().unique()
+    if schedule.size == 0:
+        raise ValueError("rebalance_schedule must contain at least one timestamp.")
+    missing_dates = schedule.difference(returns.index)
+    if not missing_dates.empty:
+        raise ValueError(
+            "Rebalance dates not present in returns index: "
+            f"{[ts.isoformat() for ts in missing_dates]}"
+        )
+
+    target_frame = _resolve_target_frame(schedule, target_weights)
+
+    all_assets = returns.columns.union(target_frame.columns)
+    returns = returns.reindex(columns=all_assets)
+    target_frame = target_frame.reindex(columns=all_assets, fill_value=0.0)
+
+    if initial_weights is not None:
+        current_weights = _normalise_row(
+            _as_weight_series(initial_weights).reindex(all_assets, fill_value=0.0)
+        )
+    else:
+        current_weights = pd.Series(0.0, index=all_assets)
+
+    nav_values: list[float] = []
+    portfolio_returns: list[float] = []
+    weight_records: list[pd.Series] = []
+    current_nav = float(initial_nav)
+
+    for ts, period_returns in returns.sort_index().iterrows():
+        if ts in target_frame.index:
+            current_weights = target_frame.loc[ts].reindex(all_assets, fill_value=0.0)
+
+        period_returns = period_returns.fillna(pd.NA)
+        available_mask = period_returns.notna()
+        adjusted_weights = current_weights.copy()
+        adjusted_weights.loc[~available_mask] = 0.0
+
+        if available_mask.any():
+            active_assets = all_assets[available_mask]
+            total_active = adjusted_weights.loc[active_assets].sum()
+            if total_active <= 0:
+                adjusted_weights.loc[active_assets] = 1.0 / len(active_assets)
+            else:
+                adjusted_weights.loc[active_assets] /= total_active
+        else:
+            adjusted_weights[:] = 0.0
+
+        weight_records.append(adjusted_weights.copy())
+
+        if available_mask.any():
+            clean_returns = period_returns.fillna(0.0)
+            prev_nav = current_nav
+            holdings_before = adjusted_weights * prev_nav
+            holdings_after = holdings_before * (1.0 + clean_returns)
+            current_nav = float(holdings_after.sum())
+            portfolio_return = 0.0 if prev_nav == 0 else current_nav / prev_nav - 1.0
+            if current_nav > 0:
+                current_weights = holdings_after.reindex(all_assets, fill_value=0.0) / current_nav
+            else:
+                current_weights = pd.Series(0.0, index=all_assets)
+        else:
+            portfolio_return = 0.0
+
+        portfolio_returns.append(float(portfolio_return))
+        nav_values.append(float(current_nav))
+
+    weights = pd.DataFrame(weight_records, index=returns.index, columns=all_assets).fillna(0.0)
+    portfolio_return_series = pd.Series(portfolio_returns, index=returns.index)
+    nav_series = pd.Series(nav_values, index=returns.index)
+
+    return RebalanceResult(weights=weights, portfolio_returns=portfolio_return_series, nav=nav_series)
+
+
+def schedule_from_optimizations(
+    optimisation_results: Mapping[Any, Mapping[str, float] | pd.Series],
+    *,
+    returns_index: pd.Index | None = None,
+) -> pd.DataFrame:
+    """Convert optimisation outputs into a rebalance schedule DataFrame."""
+
+    entries = [(_to_utc_timestamp(key), value) for key, value in optimisation_results.items()]
+    if not entries:
+        raise ValueError("optimisation_results must not be empty.")
+
+    entries.sort(key=lambda item: item[0])
+
+    rows = []
+    columns: set[str] = set()
+    timestamps = []
+    for ts, value in entries:
+        weights = _as_weight_series(value)
+        columns.update(weights.index.tolist())
+        rows.append(weights)
+        timestamps.append(ts)
+
+    timestamp_index = pd.DatetimeIndex(timestamps)
+    frame = pd.DataFrame(rows, index=timestamp_index).reindex(columns=sorted(columns), fill_value=0.0)
+    frame = _normalise_frame_rows(frame)
+
+    if returns_index is not None:
+        returns_idx = _ensure_datetime_index(returns_index)
+        missing = frame.index.difference(returns_idx)
+        if not missing.empty:
+            raise ValueError(
+                "Optimisation schedule contains dates outside the returns index: "
+                f"{[ts.isoformat() for ts in missing]}"
+            )
+
+    return frame
+
+
+def schedule_from_user_weights(
+    *,
+    dates: Sequence[pd.Timestamp | str],
+    weights: (
+        Mapping[str, float] | pd.Series | Sequence[Mapping[str, float] | pd.Series]
+    ),
+    returns_index: pd.Index | None = None,
+) -> pd.DataFrame:
+    """Construct a rebalance schedule from user-provided weights."""
+
+    if not dates:
+        raise ValueError("dates must not be empty.")
+
+    timestamp_index = _ensure_datetime_index(dates)
+    timestamp_index = timestamp_index.sort_values()
+
+    if isinstance(weights, (Mapping, pd.Series)):
+        weight_series = [_as_weight_series(weights) for _ in timestamp_index]
+    else:
+        weight_list = list(weights)
+        if len(weight_list) != len(timestamp_index):
+            raise ValueError("Length of weights sequence must match number of dates.")
+        weight_series = [_as_weight_series(w) for w in weight_list]
+
+    columns: set[str] = set()
+    for series in weight_series:
+        columns.update(series.index.tolist())
+
+    frame = pd.DataFrame(weight_series, index=timestamp_index).reindex(columns=sorted(columns), fill_value=0.0)
+    frame = _normalise_frame_rows(frame)
+
+    if returns_index is not None:
+        returns_idx = _ensure_datetime_index(returns_index)
+        missing = frame.index.difference(returns_idx)
+        if not missing.empty:
+            raise ValueError(
+                "Manual schedule contains dates outside the returns index: "
+                f"{[ts.isoformat() for ts in missing]}"
+            )
+
+    return frame

--- a/tests/fixtures/portfolio/two_asset_missing_rebalance.json
+++ b/tests/fixtures/portfolio/two_asset_missing_rebalance.json
@@ -1,0 +1,13 @@
+{
+  "description": "Attempted rebalance into an asset without return history, expected to fail because the weights collapse to zero after alignment.",
+  "initial_nav": 1.0,
+  "returns": [
+    {"date": "2024-02-05", "AssetA": 0.01, "AssetB": 0.02},
+    {"date": "2024-02-12", "AssetA": -0.015, "AssetB": 0.005},
+    {"date": "2024-02-19", "AssetA": 0.0, "AssetB": 0.0}
+  ],
+  "schedule": [
+    {"date": "2024-02-05", "weights": {"AssetA": 0.5, "AssetB": 0.5}},
+    {"date": "2024-02-19", "weights": {"MissingAsset": 1.0}}
+  ]
+}

--- a/tests/fixtures/portfolio/two_asset_weekly_rebalances.json
+++ b/tests/fixtures/portfolio/two_asset_weekly_rebalances.json
@@ -1,0 +1,26 @@
+{
+  "description": "Five weekly observations for a two-asset portfolio rebalance from 70/30 to 0/100 with missing returns treated as flat performance.",
+  "initial_nav": 1.0,
+  "returns": [
+    {"date": "2024-01-01", "AssetA": 0.01, "AssetB": 0.005},
+    {"date": "2024-01-08", "AssetA": 0.015, "AssetB": null},
+    {"date": "2024-01-15", "AssetA": -0.02, "AssetB": 0.012},
+    {"date": "2024-01-22", "AssetA": null, "AssetB": 0.01},
+    {"date": "2024-01-29", "AssetA": 0.0, "AssetB": -0.005}
+  ],
+  "schedule": [
+    {"date": "2024-01-01", "weights": {"AssetA": 0.7, "AssetB": 0.3}},
+    {"date": "2024-01-22", "weights": {"AssetA": 0.0, "AssetB": 1.0}}
+  ],
+  "expected_nav": [
+    {"date": "2024-01-01", "nav": 1.0085},
+    {"date": "2024-01-08", "nav": 1.01908925},
+    {"date": "2024-01-15", "nav": 1.0084907218},
+    {"date": "2024-01-22", "nav": 1.018575629018},
+    {"date": "2024-01-29", "nav": 1.0134827508729098}
+  ],
+  "expected_apy": {
+    "2024-01-01": 0.22919179921493785,
+    "2024-01-22": 0.13864364655315664
+  }
+}

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -32,3 +32,72 @@ def test_allocate_mean_variance_with_bounds():
     risk = portfolio.tvl_weighted_risk(returns, w, rm="MV")
     manual_risk = rp.Risk_Contribution(w, returns, returns.cov(), rm="MV").sum()
     assert risk == pytest.approx(float(manual_risk))
+
+
+def test_rebalance_engine_handles_asset_dropout_and_addition():
+    idx = pd.date_range("2024-01-01", periods=4, freq="D", tz="UTC")
+    returns = pd.DataFrame(
+        {
+            "A": [0.01, -0.02, 0.03, 0.0],
+            "B": [0.02, 0.01, -0.01, 0.02],
+            "C": [0.015, 0.0, np.nan, np.nan],
+            "D": [np.nan, np.nan, 0.05, 0.01],
+        },
+        index=idx,
+    )
+
+    targets = {
+        idx[0]: {"A": 0.5, "B": 0.3, "C": 0.2},
+        idx[3]: {"A": 0.4, "B": 0.3, "D": 0.3},
+    }
+
+    result = portfolio.rebalance_portfolio(
+        returns,
+        rebalance_schedule=[idx[0], idx[3]],
+        target_weights=targets,
+    )
+
+    weights = result.weights
+    assert pytest.approx(1.0) == weights.loc[idx[0]].sum()
+    assert weights.loc[idx[2], "C"] == pytest.approx(0.0)
+    assert weights.loc[idx[2], ["A", "B"]].sum() == pytest.approx(1.0)
+    assert weights.loc[idx[3], "D"] == pytest.approx(0.3)
+    assert pytest.approx(1.0) == weights.loc[idx[3]].sum()
+    assert result.nav.iloc[-1] > 0
+
+
+def test_schedule_helpers_enforce_alignment():
+    idx = pd.date_range("2024-02-01", periods=5, freq="D", tz="UTC")
+    returns = pd.DataFrame(
+        {
+            "A": np.linspace(0.0, 0.02, num=5),
+            "B": np.linspace(0.01, -0.01, num=5),
+        },
+        index=idx,
+    )
+
+    manual_schedule = portfolio.schedule_from_user_weights(
+        dates=[idx[0], idx[2], idx[4]],
+        weights={"A": 0.6, "B": 0.4},
+        returns_index=returns.index,
+    )
+    assert manual_schedule.index.equals(idx[[0, 2, 4]])
+    assert all(manual_schedule.sum(axis=1).round(8) == 1.0)
+
+    optimised = {
+        idx[0]: pd.Series({"A": 0.7, "B": 0.3}),
+        idx[3]: pd.Series({"A": 0.2, "B": 0.8}),
+    }
+    opt_schedule = portfolio.schedule_from_optimizations(
+        optimised,
+        returns_index=returns.index,
+    )
+    assert opt_schedule.index.equals(idx[[0, 3]])
+    assert all(opt_schedule.sum(axis=1).round(8) == 1.0)
+
+    with pytest.raises(ValueError):
+        portfolio.schedule_from_user_weights(
+            dates=[idx[0], idx[-1] + pd.Timedelta(days=1)],
+            weights={"A": 0.5, "B": 0.5},
+            returns_index=returns.index,
+        )

--- a/tests/test_portfolio_rebalances.py
+++ b/tests/test_portfolio_rebalances.py
@@ -1,0 +1,111 @@
+"""Regression fixtures for portfolio rebalances with deterministic outcomes.
+
+The JSON fixtures under ``tests/fixtures/portfolio`` provide hand-crafted
+two-asset return paths and rebalance instructions so contributors can validate
+NAV and APY calculations:
+
+* ``two_asset_weekly_rebalances.json`` contains five weekly observations. The
+  portfolio begins at a 70%/30% split, rebalances to a 0%/100% allocation on the
+  fourth timestamp, and includes missing return values that should be interpreted
+  as flat performance. Expected NAV levels and APY results for each rebalance are
+  embedded in the fixture for regression checks.
+* ``two_asset_missing_rebalance.json`` describes a scenario where the schedule
+  attempts to shift entirely into an asset without price history. When the
+  rebalance date arrives the weights collapse to zero after alignment with the
+  available return columns, so the implementation should raise ``ValueError``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from stable_yield_lab.performance import nav_series
+from stable_yield_lab import portfolio
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "portfolio"
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    with (_FIXTURE_DIR / name).open() as handle:
+        return json.load(handle)
+
+
+def _returns_from_fixture(raw_returns: Iterable[dict[str, object]]) -> pd.DataFrame:
+    frame = pd.DataFrame(raw_returns)
+    index = pd.to_datetime(frame.pop("date"), utc=True)
+    return frame.astype(float).set_index(index)
+
+
+def _schedule_from_fixture(raw_schedule: Iterable[dict[str, object]]) -> list[tuple[pd.Timestamp, pd.Series]]:
+    schedule: list[tuple[pd.Timestamp, pd.Series]] = []
+    for entry in raw_schedule:
+        ts = pd.Timestamp(entry["date"], tz="UTC")
+        weights = pd.Series(entry["weights"], dtype=float)
+        schedule.append((ts, weights))
+    return sorted(schedule, key=lambda item: item[0])
+
+
+def _simulate_nav_with_schedule(
+    returns: pd.DataFrame, schedule: list[tuple[pd.Timestamp, pd.Series]], initial: float
+) -> pd.Series:
+    if not schedule:
+        raise ValueError("rebalance schedule is empty")
+
+    returns = returns.sort_index()
+    nav_paths: list[pd.Series] = []
+    current_nav = float(initial)
+
+    for idx, (start, weights) in enumerate(schedule):
+        if idx + 1 < len(schedule):
+            next_start = schedule[idx + 1][0]
+            mask = (returns.index >= start) & (returns.index < next_start)
+        else:
+            mask = returns.index >= start
+        segment = returns.loc[mask]
+        if segment.empty:
+            raise ValueError(f"no return observations available for rebalance at {start.isoformat()}")
+        nav_segment = nav_series(segment, weights, initial=current_nav)
+        nav_paths.append(nav_segment)
+        current_nav = float(nav_segment.iloc[-1])
+
+    combined = pd.concat(nav_paths)
+    return combined[~combined.index.duplicated(keep="last")]
+
+
+def test_weekly_rebalances_nav_and_apy_regressions() -> None:
+    fixture = _load_fixture("two_asset_weekly_rebalances.json")
+    returns = _returns_from_fixture(fixture["returns"])
+    schedule = _schedule_from_fixture(fixture["schedule"])
+    nav = _simulate_nav_with_schedule(returns, schedule, float(fixture["initial_nav"]))
+
+    expected_nav = pd.Series(
+        data=[item["nav"] for item in fixture["expected_nav"]],
+        index=pd.to_datetime([item["date"] for item in fixture["expected_nav"]], utc=True),
+    )
+    pd.testing.assert_series_equal(nav, expected_nav, rtol=1e-12, atol=0.0, check_names=False)
+
+    expected_apy_map = fixture["expected_apy"]
+    for idx, (start, weights) in enumerate(schedule):
+        if idx + 1 < len(schedule):
+            next_start = schedule[idx + 1][0]
+            mask = (returns.index >= start) & (returns.index < next_start)
+        else:
+            mask = returns.index >= start
+        segment = returns.loc[mask]
+        apy = portfolio.expected_apy(segment, weights)
+        key = start.strftime("%Y-%m-%d")
+        assert apy == pytest.approx(float(expected_apy_map[key]))
+
+
+def test_missing_asset_rebalance_raises_value_error() -> None:
+    fixture = _load_fixture("two_asset_missing_rebalance.json")
+    returns = _returns_from_fixture(fixture["returns"])
+    schedule = _schedule_from_fixture(fixture["schedule"])
+
+    with pytest.raises(ValueError, match="weights sum to zero"):
+        _simulate_nav_with_schedule(returns, schedule, float(fixture["initial_nav"]))


### PR DESCRIPTION
## Summary
- merge the upstream `codex/modify-rebalance-engine-for-target-weights` branch to bring in the enhanced rebalance engine
- merge the upstream `codex/create-portfolio-fixtures-and-tests` branch to add portfolio regression fixtures and tests

## Testing
- `poetry run pytest -q` *(fails: DataQualityWarning expectation, NAV trajectory lookup, sample history length)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6a4b3804832f8fbb363ca31e07c9