### PR TITLE
fix: compound performance fees in net apy

### DIFF
--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -366,11 +366,15 @@ class Metrics:
     ) -> float:
         """Compute net APY after performance/management fees.
 
-        Fees are specified in basis points (1% = 100 bps).
+        Fees are specified in basis points (1% = 100 bps) and reduce the gross
+        annual growth factor ``(1 + base_apy + reward_apy)``. The resulting
+        compounding return is clamped to a minimum of ``-100%`` to avoid values
+        below a total loss.
         """
         gross = float(base_apy) + float(reward_apy)
         fee_frac = (perf_fee_bps + mgmt_fee_bps) / 10_000.0
-        return max(gross * (1.0 - fee_frac), -1.0)
+        net_growth = (1.0 + gross) * (1.0 - fee_frac)
+        return max(net_growth - 1.0, -1.0)
 
     @staticmethod
     def add_net_apy_column(


### PR DESCRIPTION
## Summary
- adjust Metrics.net_apy to apply performance and management fees to the annual growth factor before subtracting one
- document the compounded fee treatment in the docstring

## Testing
- poetry run pytest tests/test_metrics.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb4f437284832f92a55ae55373142c