### PR TITLE
refactor: centralize core models and repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Run the demo with sample historical returns to generate Net Asset Value (NAV) an
 poetry run python src/stable_yield_demo.py configs/demo.toml
 ```
 
+Core data models now live under ``stable_yield_lab.core``:
+
+```python
+from stable_yield_lab.core import Pool, PoolRepository, ReturnRepository
+```
+
 The script applies `stable_yield_lab.performance.nav_curve` and `performance.yield_curve` to compute time-series performance.
 `Visualizer.plot_nav` and `Visualizer.plot_yield` render the NAV trajectory and annualized yields.
 A steadily rising NAV indicates compounding growth; falling or flat lines flag underperformance.
@@ -51,7 +57,7 @@ For a step-by-step example, see [docs/investor_walkthrough.md](docs/investor_wal
 `stable_yield_lab.reporting.cross_section_report` now enriches the `concentration.csv`
 output with realised risk statistics whenever you supply historical returns. Pass a
 wide DataFrame of periodic returns (columns correspond to pool names) via the
-`returns` argument—`HistoricalCSVSource` and `ReturnRepository` make it easy to load
+`returns` argument—`HistoricalCSVSource` and `stable_yield_lab.core.ReturnRepository` make it easy to load
 bundled fixtures. The resulting CSV includes:
 
 - `scope`: `total`, `chain:<name>`, `stablecoin:<symbol>`, and `pool:<name>` rows.

--- a/docs/investor_walkthrough.md
+++ b/docs/investor_walkthrough.md
@@ -12,6 +12,11 @@ This guide demonstrates how to evaluate a small set of stablecoin pools using th
    ```bash
    poetry run python src/stable_yield_demo.py configs/demo.toml
    ```
+3. Import immutable pool models from the ``stable_yield_lab.core`` namespace when
+   scripting your own analytics:
+   ```python
+   from stable_yield_lab.core import Pool, PoolRepository
+   ```
 
 ## 2. Load sample performance data
 
@@ -20,6 +25,7 @@ This guide demonstrates how to evaluate a small set of stablecoin pools using th
 >>> from tempfile import TemporaryDirectory
 >>> import pandas as pd
 >>> from stable_yield_lab import Visualizer, performance
+>>> from stable_yield_lab.core import PoolRepository
 >>>
 >>> yields_df = pd.read_csv("src/sample_yields.csv", parse_dates=["timestamp"])
 >>> returns = yields_df.pivot(index="timestamp", columns="name", values="period_return")

--- a/src/stable_yield_demo.py
+++ b/src/stable_yield_demo.py
@@ -18,6 +18,7 @@ from stable_yield_lab import (
     portfolio,
     risk_metrics,
 )
+from stable_yield_lab.core import PoolRepository
 from stable_yield_lab.reporting import cross_section_report
 
 
@@ -97,11 +98,11 @@ def main() -> None:
     # Load data
     csv_path = cfg["csv"]["path"]
     src = CSVSource(path=csv_path)
-    repo = Pipeline([src]).run()
+    repo: PoolRepository = Pipeline([src]).run()
 
     # Apply filters
     f = cfg.get("filters", {})
-    filtered = repo.filter(
+    filtered: PoolRepository = repo.filter(
         min_tvl=float(f.get("min_tvl", 0.0)),
         min_base_apy=float(f.get("min_base_apy", 0.0)),
         auto_only=bool(f.get("auto_only", False)),

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -21,8 +21,7 @@ import urllib.request
 import pandas as pd
 
 from . import attribution, performance, risk_scoring
-from .core.models import Pool, PoolReturn
-from .core.repositories import PoolRepository, ReturnRepository
+from .core import Pool, PoolRepository, PoolReturn, ReturnRepository, STABLE_TOKENS
 from .performance import cumulative_return, nav_series, nav_trajectories
 
 
@@ -95,29 +94,6 @@ class HistoricalCSVSource:
 
 
 logger = logging.getLogger(__name__)
-
-STABLE_TOKENS = {
-    "USDC",
-    "USDT",
-    "DAI",
-    "FRAX",
-    "LUSD",
-    "GUSD",
-    "TUSD",
-    "USDP",
-    "USDD",
-    "USDR",
-    "USDf",
-    "USDF",
-    "MAI",
-    "SUSD",
-    "EURS",
-    "EUROE",
-    "CRVUSD",
-    "GHO",
-    "USDC.E",
-    "USDT.E",
-}
 
 
 class DefiLlamaSource:

--- a/src/stable_yield_lab/core/__init__.py
+++ b/src/stable_yield_lab/core/__init__.py
@@ -7,6 +7,7 @@ interface exposed in :mod:`stable_yield_lab.__init__`.
 
 from __future__ import annotations
 
+from .constants import STABLE_TOKENS
 from .models import Pool, PoolReturn
 from .repositories import PoolRepository, ReturnRepository
 
@@ -15,5 +16,6 @@ __all__ = [
     "PoolReturn",
     "PoolRepository",
     "ReturnRepository",
+    "STABLE_TOKENS",
 ]
 

--- a/src/stable_yield_lab/core/constants.py
+++ b/src/stable_yield_lab/core/constants.py
@@ -1,0 +1,36 @@
+"""Core constants shared across StableYieldLab modules."""
+
+from __future__ import annotations
+
+# Common stablecoins recognised by StableYieldLab data adapters.
+#
+# The list intentionally focuses on major dollar- and euro-pegged tokens to
+# filter protocols when sourcing pools from aggregators such as DefiLlama or
+# Morpho.  Keeping the canonical symbols in :mod:`stable_yield_lab.core`
+# avoids circular imports when consumers only need the lightweight data model
+# layer.
+STABLE_TOKENS = {
+    "USDC",
+    "USDT",
+    "DAI",
+    "FRAX",
+    "LUSD",
+    "GUSD",
+    "TUSD",
+    "USDP",
+    "USDD",
+    "USDR",
+    "USDf",
+    "USDF",
+    "MAI",
+    "SUSD",
+    "EURS",
+    "EUROE",
+    "CRVUSD",
+    "GHO",
+    "USDC.E",
+    "USDT.E",
+}
+
+__all__ = ["STABLE_TOKENS"]
+

--- a/src/stable_yield_lab/reporting.py
+++ b/src/stable_yield_lab/reporting.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 import pandas as pd
 
+from stable_yield_lab.core import PoolRepository
+
 from . import Metrics
-from .core.repositories import PoolRepository
 
 _RISK_COLUMNS = [
     "sharpe_ratio",

--- a/src/stable_yield_lab/risk_scoring.py
+++ b/src/stable_yield_lab/risk_scoring.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from typing import Mapping, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
-    from .core.models import Pool
+    from stable_yield_lab.core import Pool
 
 # Simple reputation mapping per chain. Values range from 0 (unknown) to 1 (blue chip).
 CHAIN_REPUTATION: Mapping[str, float] = {

--- a/tests/core/test_repositories.py
+++ b/tests/core/test_repositories.py
@@ -1,0 +1,91 @@
+import pytest
+
+from stable_yield_lab.core import Pool, PoolRepository
+
+
+@pytest.fixture
+def sample_pools() -> list[Pool]:
+    """Synthetic pool universe covering assorted filter attributes."""
+
+    return [
+        Pool(
+            name="HighTVL",
+            chain="Ethereum",
+            stablecoin="USDC",
+            tvl_usd=200_000.0,
+            base_apy=0.05,
+            is_auto=True,
+        ),
+        Pool(
+            name="HighAPY",
+            chain="Ethereum",
+            stablecoin="DAI",
+            tvl_usd=50_000.0,
+            base_apy=0.12,
+            is_auto=False,
+        ),
+        Pool(
+            name="AutoYield",
+            chain="Polygon",
+            stablecoin="USDT",
+            tvl_usd=150_000.0,
+            base_apy=0.09,
+            is_auto=True,
+        ),
+        Pool(
+            name="EuroPool",
+            chain="Arbitrum",
+            stablecoin="EURS",
+            tvl_usd=300_000.0,
+            base_apy=0.04,
+            is_auto=True,
+        ),
+    ]
+
+
+@pytest.fixture
+def repository(sample_pools: list[Pool]) -> PoolRepository:
+    return PoolRepository(sample_pools)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({"min_tvl": 100_000.0}, ["HighTVL", "AutoYield", "EuroPool"]),
+        ({"min_base_apy": 0.08}, ["HighAPY", "AutoYield"]),
+        ({"auto_only": True}, ["HighTVL", "AutoYield", "EuroPool"]),
+        ({"stablecoins": ["USDC", "DAI"]}, ["HighTVL", "HighAPY"]),
+    ],
+)
+def test_filter_respects_criteria(
+    repository: PoolRepository,
+    sample_pools: list[Pool],
+    kwargs: dict[str, object],
+    expected: list[str],
+) -> None:
+    filtered = repository.filter(**kwargs)
+
+    assert isinstance(filtered, PoolRepository)
+    assert [pool.name for pool in filtered] == expected
+
+    # Original repository order remains unchanged and deterministic ordering is preserved.
+    assert [pool.name for pool in repository] == [pool.name for pool in sample_pools]
+
+
+def test_filter_returns_new_repository_instance(repository: PoolRepository) -> None:
+    filtered = repository.filter(min_tvl=0.0)
+
+    assert filtered is not repository
+    assert list(filtered) == list(repository)
+
+    extra_pool = Pool(
+        name="NewPool",
+        chain="Base",
+        stablecoin="USDC",
+        tvl_usd=10_000.0,
+        base_apy=0.03,
+    )
+    filtered.add(extra_pool)
+
+    assert len(filtered) == len(repository) + 1
+    assert len(repository) == 4

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -6,8 +6,7 @@ import pandas as pd
 import pytest
 
 from stable_yield_lab import attribution
-from stable_yield_lab.core.models import Pool
-from stable_yield_lab.core.repositories import PoolRepository
+from stable_yield_lab.core import Pool, PoolRepository
 from stable_yield_lab.reporting import cross_section_report
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,5 @@
 from stable_yield_lab import Metrics
-from stable_yield_lab.core.models import Pool
-from stable_yield_lab.core.repositories import PoolRepository
+from stable_yield_lab.core import Pool, PoolRepository
 
 
 def test_net_apy() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from stable_yield_lab import CSVSource, Pipeline
-from stable_yield_lab.core.models import Pool
+from stable_yield_lab.core import Pool
 from stable_yield_lab.risk_scoring import calculate_risk_score
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,8 +7,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from stable_yield_lab.core.models import Pool
-from stable_yield_lab.core.repositories import PoolRepository
+from stable_yield_lab.core import Pool, PoolRepository
 from stable_yield_lab.reporting import cross_section_report
 
 

--- a/tests/test_reporting_realised_apy.py
+++ b/tests/test_reporting_realised_apy.py
@@ -3,8 +3,7 @@ from pathlib import Path
 import pandas as pd
 
 from stable_yield_lab import HistoricalCSVSource, Pipeline
-from stable_yield_lab.core.models import Pool
-from stable_yield_lab.core.repositories import PoolRepository
+from stable_yield_lab.core import Pool, PoolRepository
 from stable_yield_lab.reporting import cross_section_report
 
 

--- a/tests/test_risk_scoring.py
+++ b/tests/test_risk_scoring.py
@@ -1,4 +1,4 @@
-from stable_yield_lab.core.models import Pool
+from stable_yield_lab.core import Pool
 from stable_yield_lab.risk_scoring import calculate_risk_score, score_pool
 
 

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -5,7 +5,7 @@ from stable_yield_lab import (
     DefiLlamaSource,
     MorphoSource,
 )
-from stable_yield_lab.core.repositories import PoolRepository
+from stable_yield_lab.core import PoolRepository
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 


### PR DESCRIPTION
## Summary
- expose `Pool`, `PoolReturn`, `PoolRepository`, `ReturnRepository`, and `STABLE_TOKENS` from `stable_yield_lab.core` and import them from `stable_yield_lab.__init__`
- update the demo, reporting utilities, risk scoring, and documentation/tests to reference the new core namespace
- add repository filtering tests that cover the main selectors, ordering guarantees, and fresh instance behaviour

## Testing
- poetry run pytest -q *(fails: existing suite expects legacy reporting arguments, historical fixtures, and portfolio helpers)*
- poetry run pytest tests/core/test_repositories.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cb5a2a66a8832f9171ec02f01e7815