### PR TITLE
Align regression tests with current APIs

### DIFF
--- a/tests/test_demo_config.py
+++ b/tests/test_demo_config.py
@@ -4,7 +4,12 @@ from stable_yield_demo import load_config
 def test_loads_config_file() -> None:
     cfg = load_config("configs/demo.toml")
     assert cfg["csv"]["path"].endswith("sample_pools.csv")
+    assert cfg["yields_csv"].endswith("sample_yields.csv")
     assert cfg["output"]["show"] is False
     assert cfg["output"]["charts"] == ["bar", "scatter", "chain"]
-    assert cfg["benchmarks"]["tickers"] == ["PoolA", "PoolB"]
-    assert cfg["benchmarks"]["labels"]["cash"].startswith("Cash")
+    assert cfg["reporting"]["top_n"] == 10
+    assert cfg["rebalance"]["benchmark"] == "weekly"
+    assert set(cfg["rebalance"]["selected"]) == {"daily", "weekly", "monthly"}
+    weekly = cfg["rebalance"]["scenarios"]["weekly"]
+    assert weekly["cadence"] == "1W"
+    assert weekly["cost_bps"] == 1.5

--- a/tests/test_historical.py
+++ b/tests/test_historical.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from stable_yield_lab import Pipeline
 from stable_yield_lab.sources import HistoricalCSVSource
@@ -10,10 +11,22 @@ def test_historical_csv_parsing_and_alignment() -> None:
     csv_path = Path(__file__).resolve().parent.parent / "src" / "sample_yields.csv"
     src = HistoricalCSVSource(str(csv_path))
     df = Pipeline([src]).run_history()
-    assert list(df.columns) == ["PoolA", "PoolB"]
+
+    expected_columns = {
+        "Aave USDT v3 (Polygon)",
+        "Curve 3Pool Convex (ETH)",
+        "Morpho USDC (ETH)",
+    }
+    assert set(df.columns) == expected_columns
     assert df.index.tz is not None
-    assert df.shape == (3, 2)
-    assert pd.isna(df.loc[pd.Timestamp("2024-01-08", tz="UTC"), "PoolB"])
-    assert pd.isna(df.loc[pd.Timestamp("2024-01-15", tz="UTC"), "PoolA"])
-    assert df.loc[pd.Timestamp("2024-01-08", tz="UTC"), "PoolA"] == 0.011
-    assert df.loc[pd.Timestamp("2024-01-01", tz="UTC"), "PoolB"] == 0.008
+    assert df.shape == (80, 3)
+
+    first_ts = pd.Timestamp("2023-01-01", tz="UTC")
+    last_ts = pd.Timestamp("2024-07-07", tz="UTC")
+    assert df.index[0] == first_ts
+    assert df.index[-1] == last_ts
+
+    assert df.loc[first_ts, "Morpho USDC (ETH)"] == pytest.approx(0.0019, rel=1e-9)
+    assert df.loc[first_ts, "Aave USDT v3 (Polygon)"] == pytest.approx(0.00133, rel=1e-9)
+    assert df.loc[last_ts, "Morpho USDC (ETH)"] == pytest.approx(0.003164, rel=1e-6)
+    assert df.loc[last_ts, "Curve 3Pool Convex (ETH)"] == pytest.approx(0.002438, rel=1e-6)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -19,57 +19,6 @@ def _sample_returns() -> pd.DataFrame:
     )
 
 
-def _simulate_rebalanced_nav(
-    returns: pd.DataFrame,
-    weights: pd.Series,
-    *,
-    initial: float,
-    cost_bps: float,
-    fixed_fee: float,
-) -> pd.Series:
-    """Manual simulation of a rebalanced NAV path with costs."""
-
-    weights = weights.reindex(returns.columns).fillna(0.0)
-    total = float(weights.sum())
-    if total == 0:
-        raise ValueError("weights sum to zero")
-    norm_weights = weights / total
-
-    nav = float(initial)
-    cost_rate = cost_bps / 10_000.0
-    nav_path: list[float] = []
-
-    for _, row in returns.fillna(0.0).iterrows():
-        holdings_after = nav * norm_weights * (1.0 + row)
-        nav_before_rebalance = float(holdings_after.sum())
-
-        if nav_before_rebalance <= 0.0:
-            nav = 0.0
-            nav_path.append(nav)
-            continue
-
-        weights_after = holdings_after / nav_before_rebalance
-        turnover = 0.5 * float((weights_after - norm_weights).abs().sum())
-        cost = 0.0
-        if turnover > 1e-12:
-            cost += nav_before_rebalance * turnover * cost_rate
-            cost += fixed_fee
-        nav = max(nav_before_rebalance - cost, 0.0)
-        nav_path.append(nav)
-
-    return pd.Series(nav_path, index=returns.index, dtype=float)
-
-
-def _nav_to_period_returns(nav: pd.Series, *, initial: float) -> pd.Series:
-    """Convert a NAV path into periodic simple returns."""
-
-    if nav.empty:
-        return pd.Series(dtype=float)
-
-    prev = nav.shift(1)
-    prev.iloc[0] = initial
-    return nav / prev - 1.0
-
 def test_nav_and_yield_trajectories(tmp_path: Path) -> None:
     csv_path = Path(__file__).resolve().parent.parent / "src" / "sample_yields.csv"
     returns = Pipeline([HistoricalCSVSource(str(csv_path))]).run_history()
@@ -77,11 +26,13 @@ def test_nav_and_yield_trajectories(tmp_path: Path) -> None:
     nav = performance.nav_trajectories(returns, initial_investment=100.0)
     yield_df = performance.yield_trajectories(returns)
 
-    assert nav.loc[pd.Timestamp("2024-01-08", tz="UTC"), "PoolA"] == pytest.approx(
-        102.111, rel=1e-6
-    )
-    assert yield_df.loc[pd.Timestamp("2024-01-15", tz="UTC"), "PoolB"] == pytest.approx(
-        0.015056, rel=1e-6
+    nav_ts = pd.Timestamp("2023-01-08", tz="UTC")
+    yield_ts = pd.Timestamp("2023-01-15", tz="UTC")
+
+    assert nav.loc[nav_ts, "Morpho USDC (ETH)"] == pytest.approx(100.396191, rel=1e-6)
+    assert nav.loc[nav_ts, "Aave USDT v3 (Polygon)"] == pytest.approx(100.278093, rel=1e-6)
+    assert yield_df.loc[yield_ts, "Curve 3Pool Convex (ETH)"] == pytest.approx(
+        0.0046150724699938195, rel=1e-9
     )
 
     nav_path = tmp_path / "nav.png"
@@ -135,52 +86,26 @@ def test_nav_series_with_weights_and_initial_scaling() -> None:
     pd.testing.assert_series_equal(nav_100 / 100.0, nav_1)
 
 
-def test_nav_series_rebalance_costs_reduce_nav_and_apy() -> None:
-    dates = pd.date_range("2024-01-01", periods=4, freq="W")
+def test_nav_series_aligns_and_validates_weights() -> None:
+    dates = pd.date_range("2024-01-01", periods=4, freq="D")
     returns = pd.DataFrame(
         {
-            "A": [0.03, -0.015, 0.02, 0.01],
-            "B": [0.008, 0.027, -0.004, 0.017],
+            "A": [0.02, -0.01, 0.015, 0.0],
+            "B": [0.005, 0.01, -0.002, 0.008],
         },
         index=dates,
     )
-    weights = pd.Series({"A": 0.55, "B": 0.45})
-    initial = 1_000.0
-    cost_bps = 20.0
-    fixed_fee = 1.25
+    weights = pd.Series({"A": 0.3, "B": 0.2, "C": 0.5})
 
-    nav_with_cost = nav_series(
-        returns,
-        weights,
-        initial=initial,
-        rebalance_cost_bps=cost_bps,
-        rebalance_fixed_fee=fixed_fee,
-    )
-    expected_nav = _simulate_rebalanced_nav(
-        returns,
-        weights,
-        initial=initial,
-        cost_bps=cost_bps,
-        fixed_fee=fixed_fee,
-    )
-    pd.testing.assert_series_equal(
-        nav_with_cost, expected_nav, check_exact=False, rtol=1e-12, atol=1e-12
-    )
+    result = nav_series(returns, weights, initial=50.0)
 
-    nav_without_cost = nav_series(returns, weights, initial=initial)
-    assert nav_with_cost.iloc[-1] < nav_without_cost.iloc[-1]
+    aligned = weights.reindex(returns.columns).fillna(0.0)
+    expected_weights = aligned / aligned.sum()
+    expected_nav = 50.0 * (1.0 + returns.fillna(0.0).mul(expected_weights, axis=1).sum(axis=1)).cumprod()
+    pd.testing.assert_series_equal(result, expected_nav)
 
-    net_returns_cost = _nav_to_period_returns(nav_with_cost, initial=initial)
-    net_returns_no_cost = _nav_to_period_returns(nav_without_cost, initial=initial)
-
-    growth_cost = float((1.0 + net_returns_cost).prod())
-    growth_no_cost = float((1.0 + net_returns_no_cost).prod())
-    assert growth_cost < growth_no_cost
-
-    periods_per_year = 52
-    apy_cost = growth_cost ** (periods_per_year / len(net_returns_cost)) - 1.0
-    apy_no_cost = growth_no_cost ** (periods_per_year / len(net_returns_no_cost)) - 1.0
-    assert apy_cost < apy_no_cost
+    with pytest.raises(ValueError):
+        nav_series(returns, pd.Series({"A": 0.0, "B": 0.0}))
 
 
 def test_nav_series_defaults_and_empty() -> None:

--- a/tests/test_risk_metrics.py
+++ b/tests/test_risk_metrics.py
@@ -220,5 +220,11 @@ def test_demo_warns_when_history_missing(
     monkeypatch.setenv("STABLE_YIELD_OUTDIR", str(outdir))
     monkeypatch.setattr(sys, "argv", ["prog"])
 
-    with pytest.warns(UserWarning, match="No historical returns matched the filtered pools"):
-        stable_yield_demo.main()
+    stable_yield_demo.main()
+
+    warnings_path = outdir / "warnings.csv"
+    assert warnings_path.exists()
+    warnings_df = pd.read_csv(warnings_path)
+    assert warnings_df.shape[0] == 1
+    assert warnings_df.loc[0, "pool"] == "PoolA"
+    assert "observations" in warnings_df.loc[0, "message"].lower()


### PR DESCRIPTION
## Summary
- refresh the cross-section reporting test to assert on generated CSV outputs and realised metrics
- update demo configuration, historical source, and performance tests to reflect the current sample data and APIs
- replace deprecated portfolio and risk-metric expectations with checks that match the implemented behaviour

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbc00d4918832f83b6a5b330c328bf