### PR TITLE
ci: centralize codex request automation

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -12,6 +12,14 @@ These instructions cover files in `.github/` including GitHub Actions workflows.
 - Automation scripts should respect repository `AGENTS.md` instructions and maintain determinism.
 - Avoid committing secrets; reference credentials through encrypted repository secrets.
 - Reusable workflows should expose parameters clearly and default to safe settings.
+- Use the shared `.github/actions/codex-request` composite action for posting Codex follow-up comments instead of embedding bespoke scripts.
+  - Inputs:
+    - `comment-body`: the full message posted to the issue or pull request.
+    - `trigger-text`: identifying text used inside the body and for duplicate detection.
+    - `dedupe`: set to `true` to skip when the bot has already posted the `trigger-text`.
+    - `require-existing-comment`, `existing-comment-query`, and `existing-comment-author`: enable optional gating on existing discussion before posting.
+  - Always pass `github-token: ${{ github.token }}` (or a token with equivalent permissions).
+  - Extend the action with new inputs rather than forking scripts in other workflows.
 
 ## Reviews
 - CI changes require review from maintainers familiar with infrastructure.

--- a/.github/actions/codex-request/action.yml
+++ b/.github/actions/codex-request/action.yml
@@ -1,0 +1,100 @@
+name: Codex request comment
+
+description: Post a standardized Codex request comment with optional duplicate suppression and existing-comment checks.
+
+inputs:
+  github-token:
+    description: Token with permission to create issue or pull request comments.
+    required: true
+  comment-body:
+    description: The body of the comment to create.
+    required: true
+  trigger-text:
+    description: Text used to describe the automation trigger and to detect duplicates.
+    required: true
+  dedupe:
+    description: Set to "true" to skip creating a new comment when a matching bot comment already exists.
+    required: false
+    default: 'false'
+  require-existing-comment:
+    description: Set to "true" to only post when a matching existing comment is present.
+    required: false
+    default: 'false'
+  existing-comment-query:
+    description: Optional substring to search for when require-existing-comment is enabled. Defaults to trigger-text when omitted.
+    required: false
+    default: ''
+  existing-comment-author:
+    description: Optional login that an existing comment must match when require-existing-comment is enabled.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Submit Codex request comment
+      uses: actions/github-script@v7
+      with:
+        github-token: ${{ inputs.github-token }}
+        result-encoding: string
+        script: |
+          const commentBody = core.getInput('comment-body', { required: true });
+          const triggerText = core.getInput('trigger-text', { required: true });
+          const dedupe = core.getBooleanInput('dedupe');
+          const requireExisting = core.getBooleanInput('require-existing-comment');
+          const existingQueryInput = core.getInput('existing-comment-query');
+          const existingAuthor = core.getInput('existing-comment-author');
+          const existingQuery = existingQueryInput || triggerText;
+
+          if (!context.issue?.number) {
+            core.setFailed('No issue or pull request number available in the current context.');
+            return;
+          }
+
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            ...context.repo,
+            issue_number: context.issue.number,
+            per_page: 100
+          });
+
+          if (requireExisting) {
+            const found = comments.some((comment) => {
+              if (existingAuthor && comment.user?.login !== existingAuthor) {
+                return false;
+              }
+              return comment.body?.includes(existingQuery);
+            });
+
+            if (!found) {
+              core.info(`No existing comment found containing "${existingQuery}"${existingAuthor ? ` from ${existingAuthor}` : ''}. Skipping Codex request.`);
+              return;
+            }
+          }
+
+          if (dedupe) {
+            const duplicate = comments.some((comment) => {
+              if (comment.user?.login !== 'github-actions[bot]') {
+                return false;
+              }
+              return comment.body?.includes(triggerText);
+            });
+
+            if (duplicate) {
+              core.info(`Codex request already posted for trigger "${triggerText}". Skipping duplicate.`);
+              return;
+            }
+          }
+
+          await github.rest.issues.createComment({
+            ...context.repo,
+            issue_number: context.issue.number,
+            body: commentBody
+          });
+
+          core.info('Codex request comment created.');
+      comment-body: ${{ inputs.comment-body }}
+      trigger-text: ${{ inputs.trigger-text }}
+      dedupe: ${{ inputs.dedupe }}
+      require-existing-comment: ${{ inputs.require-existing-comment }}
+      existing-comment-query: ${{ inputs.existing-comment-query }}
+      existing-comment-author: ${{ inputs.existing-comment-author }}

--- a/.github/workflows/codex-comments.yml
+++ b/.github/workflows/codex-comments.yml
@@ -14,17 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request Codex follow-up
-        uses: actions/github-script@v7
+        uses: ./.github/actions/codex-request
         with:
-          script: |
-            const body = [
-              '@codex please review the latest discussion.',
-              '',
-              'Summarize the thread, propose next actions, and flag owners who should respond.'
-            ].join('\n');
+          github-token: ${{ github.token }}
+          comment-body: |
+            @codex please review the latest discussion.
 
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body
-            });
+            Summarize the thread, propose next actions, and flag owners who should respond.
+          trigger-text: '@codex please review the latest discussion.'

--- a/.github/workflows/codex-issues.yml
+++ b/.github/workflows/codex-issues.yml
@@ -13,17 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request Codex triage
-        uses: actions/github-script@v7
+        uses: ./.github/actions/codex-request
         with:
-          script: |
-            const body = [
-              '@codex please help triage this issue.',
-              '',
-              'Review the report, reproduce if possible, label severity, and outline next steps for the team.'
-            ].join('\n');
+          github-token: ${{ github.token }}
+          comment-body: |
+            @codex please help triage this issue.
 
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body
-            });
+            Review the report, reproduce if possible, label severity, and outline next steps for the team.
+          trigger-text: '@codex please help triage this issue.'

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -14,39 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request Codex review
-        uses: actions/github-script@v7
+        uses: ./.github/actions/codex-request
         with:
-          script: |
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              {
-                ...context.repo,
-                issue_number: context.issue.number,
-                per_page: 100
-              }
-            );
+          github-token: ${{ github.token }}
+          comment-body: |
+            @codex please review this pull request.
 
-            const alreadyRequested = comments.some((comment) => {
-              if (comment.user?.login !== 'github-actions[bot]') {
-                return false;
-              }
-              return comment.body?.includes('@codex please review this pull request.') ?? false;
-            });
-
-            if (alreadyRequested) {
-              core.info('Codex review already requested for this pull request.');
-              return;
-            }
-
-            const body = [
-              '@codex please review this pull request.',
-              '',
-              'Focus on test coverage, correctness, security considerations, and any missing documentation.',
-              'Share prioritized follow-up tasks for the maintainers.'
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.issue.number,
-              body
-            });
+            Focus on test coverage, correctness, security considerations, and any missing documentation.
+            Share prioritized follow-up tasks for the maintainers.
+          trigger-text: '@codex please review this pull request.'
+          dedupe: true


### PR DESCRIPTION
## Summary
- add a reusable `.github/actions/codex-request` composite action for Codex comments with configurable dedupe and gating
- refactor Codex issue, comment, and PR workflows to call the shared action
- document the new automation primitive in `.github/AGENTS.md`

## Testing
- ⚠️ `act -n -W .github/workflows/codex-review.yml` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf9ea2c4c832fa2ae5910c798f9fd