### PR TITLE
Fix GitHub Actions caching without poetry.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'poetry'
+          # poetry.lock is intentionally ignored; fall back to pyproject for cache key.
+          cache-dependency-path: pyproject.toml
 
       - name: Install Poetry
         uses: snok/install-poetry@v1

--- a/.github/workflows/daily-demo-images.yml
+++ b/.github/workflows/daily-demo-images.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           python-version: '3.12'
           cache: 'poetry'
+          # poetry.lock is intentionally ignored; fall back to pyproject for cache key.
+          cache-dependency-path: pyproject.toml
 
       - name: Install Poetry
         uses: snok/install-poetry@v1


### PR DESCRIPTION
## Summary
- configure the Python setup step in CI and demo workflows to derive the Poetry cache key from `pyproject.toml`
- document in-line that the repository intentionally ignores `poetry.lock`

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc30a7b3e4832f9b72ecb211aa421c