### PR TITLE
ci: auto-apply pre-commit fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,17 @@ concurrency:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      precommit_autofix: ${{ steps.precommit.outputs.needs_autofix }}
     env:
       DEMO_OUTDIR: demo_artifacts
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
@@ -42,9 +48,43 @@ jobs:
           poetry install --with dev --no-interaction
 
       - name: Run pre-commit
-        run: poetry run pre-commit run --color=always --show-diff-on-failure --all-files
+        id: precommit
+        run: |
+          set -eo pipefail
+          set +e
+          poetry run pre-commit run --color=always --show-diff-on-failure --all-files
+          exit_code=$?
+          set -e
+          echo "exit_code=${exit_code}" >>"${GITHUB_OUTPUT}"
+          if [ "${exit_code}" -eq 0 ]; then
+            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if git diff --quiet; then
+            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
+            exit "${exit_code}"
+          fi
+
+          echo "needs_autofix=true" >>"${GITHUB_OUTPUT}"
+
+      - name: Auto-commit pre-commit fixes
+        if: steps.precommit.outputs.needs_autofix == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: apply pre-commit auto-fixes"
+          branch: ${{ github.head_ref }}
+          skip_checkout: true
+
+      - name: Fail if pre-commit fixes cannot be applied automatically
+        if: steps.precommit.outputs.needs_autofix == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository)
+        run: |
+          echo '::error::pre-commit hooks modified files but CI could not push the fixes automatically.'
+          echo '::error::Please run "poetry run pre-commit run --all-files" locally and push the resulting changes.'
+          exit 1
 
       - name: Run headless demo (config-driven)
+        if: steps.precommit.outputs.needs_autofix != 'true'
         env:
           MPLBACKEND: Agg
           STABLE_YIELD_OUTDIR: ${{ env.DEMO_OUTDIR }}
@@ -74,6 +114,7 @@ jobs:
           test -s "${STABLE_YIELD_OUTDIR}/nav_vs_time.png"
 
       - name: Upload demo artifacts
+        if: steps.precommit.outputs.needs_autofix != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: demo-artifacts
@@ -81,10 +122,12 @@ jobs:
           if-no-files-found: error
 
       - name: Run tests with coverage
+        if: steps.precommit.outputs.needs_autofix != 'true'
         run: |
           poetry run pytest --cov=stable_yield_lab --cov-report=xml --cov-report=html --cov-report=term-missing
 
       - name: Prepare coverage site artifact
+        if: steps.precommit.outputs.needs_autofix != 'true'
         run: |
           poetry run python - <<'PY'
             import json
@@ -138,26 +181,28 @@ jobs:
           HTML
 
       - name: Upload coverage artifact
+        if: steps.precommit.outputs.needs_autofix != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-xml
           path: coverage.xml
 
       - name: Upload HTML coverage artifact
+        if: steps.precommit.outputs.needs_autofix != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
           path: coverage-site/report
 
       - name: Upload coverage site for Pages
-        if: github.event_name == 'push'
+        if: steps.precommit.outputs.needs_autofix != 'true' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v3
         with:
           path: coverage-site
 
   deploy-coverage:
     needs: build-test
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/gh-pages'
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/gh-pages' && needs.build-test.outputs.precommit_autofix != 'true'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/docs/sample_data_provenance.md
+++ b/docs/sample_data_provenance.md
@@ -38,13 +38,13 @@ the snippet in `tests/analytics/test_performance.py::test_nav_and_yield_trajecto
 * Metrics were computed directly from the trailing 52 weeks of
   `sample_yields.csv` using the formulas implemented in
   `tests/analytics/test_performance.py::test_sample_history_matches_expected_metrics`:
-  
+
   \[
   R = \prod_{i=1}^n (1 + r_i) - 1,\qquad
   \text{APY} = (1 + R)^{52/n} - 1,\qquad
   \sigma = \operatorname{stdev}(r_i) \sqrt{52}
   \]
-  
+
   Maximum drawdown is measured on the cumulative NAV curve derived from the
   weekly returns.
 

--- a/src/stable_yield_demo.py
+++ b/src/stable_yield_demo.py
@@ -126,7 +126,9 @@ def main() -> None:
 
     # Risk metrics derived from time-series returns
     returns = (
-        returns_ts if returns_ts is not None else df.pivot_table(index="timestamp", columns="name", values="base_apy")
+        returns_ts
+        if returns_ts is not None
+        else df.pivot_table(index="timestamp", columns="name", values="base_apy")
     )
     stats = frontier = None
     try:
@@ -185,6 +187,7 @@ def main() -> None:
         portfolio_nav = None
 
         if not returns_ts.empty and returns_ts.shape[1] > 0:
+
             def _infer_periods_per_year(index: pd.Index) -> int:
                 if len(index) < 2:
                     return 52

--- a/src/stable_yield_lab/__init__.py
+++ b/src/stable_yield_lab/__init__.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from . import analytics, risk_scoring, visualization
 from . import reporting as reporting_module
 from .analytics.metrics import Metrics
-from .analytics.performance import cumulative_return, nav_series, nav_trajectories
+from .analytics.performance import cumulative_return, nav_series
 from .core import Pool, PoolRepository, PoolReturn, ReturnRepository
 from .pipeline import Pipeline
 from .sources import (

--- a/src/stable_yield_lab/analytics/attribution.py
+++ b/src/stable_yield_lab/analytics/attribution.py
@@ -152,7 +152,10 @@ def compute_attribution(
             "periods_per_year": periods_per_year or float("nan"),
         }
         return AttributionResult(
-            portfolio=portfolio, by_pool=empty, by_window=windows, period_returns=pd.Series(dtype=float)
+            portfolio=portfolio,
+            by_pool=empty,
+            by_window=windows,
+            period_returns=pd.Series(dtype=float),
         )
 
     initial_value = float(initial_nav)
@@ -165,7 +168,9 @@ def compute_attribution(
         if not columns:
             raise ValueError("returns must contain columns when weight_schedule is None")
         weight_schedule = pd.Series(1.0 / len(columns), index=columns)
-    aligned_weights, window_labels = _prepare_weight_schedule(weight_schedule, returns_index, columns)
+    aligned_weights, window_labels = _prepare_weight_schedule(
+        weight_schedule, returns_index, columns
+    )
 
     weight_sums = aligned_weights.sum(axis=1)
     if (weight_sums <= 0).any():

--- a/src/stable_yield_lab/analytics/performance.py
+++ b/src/stable_yield_lab/analytics/performance.py
@@ -131,7 +131,6 @@ def nav_trajectories(returns: pd.DataFrame, *, initial_investment: float) -> pd.
     if returns.empty:
         return returns.copy()
 
-
     growth = (1.0 + returns.fillna(0.0)).cumprod()
     return growth * float(initial_investment)
 
@@ -312,7 +311,9 @@ def run_rebalance_scenarios(
     if returns.empty:
         empty = pd.DataFrame(index=returns.index)
         return ScenarioRunResult(
-            metrics=pd.DataFrame(columns=["realized_apy", "total_cost", "tracking_error", "terminal_nav"]),
+            metrics=pd.DataFrame(
+                columns=["realized_apy", "total_cost", "tracking_error", "terminal_nav"]
+            ),
             navs=empty,
             returns=empty,
         )

--- a/src/stable_yield_lab/analytics/portfolio.py
+++ b/src/stable_yield_lab/analytics/portfolio.py
@@ -132,8 +132,10 @@ def tracking_error(
     if portfolio_returns.empty:
         return float("nan"), float("nan")
 
-    benchmark = float(target_periodic_return) if target_periodic_return is not None else float(
-        portfolio_returns.mean()
+    benchmark = (
+        float(target_periodic_return)
+        if target_periodic_return is not None
+        else float(portfolio_returns.mean())
     )
     active = portfolio_returns - benchmark
     active = active.dropna()

--- a/src/stable_yield_lab/core/__init__.py
+++ b/src/stable_yield_lab/core/__init__.py
@@ -18,4 +18,3 @@ __all__ = [
     "ReturnRepository",
     "STABLE_TOKENS",
 ]
-

--- a/src/stable_yield_lab/core/constants.py
+++ b/src/stable_yield_lab/core/constants.py
@@ -33,4 +33,3 @@ STABLE_TOKENS = {
 }
 
 __all__ = ["STABLE_TOKENS"]
-

--- a/src/stable_yield_lab/core/models.py
+++ b/src/stable_yield_lab/core/models.py
@@ -54,4 +54,3 @@ class PoolReturn:
 
 
 __all__ = ["Pool", "PoolReturn"]
-

--- a/src/stable_yield_lab/core/repositories.py
+++ b/src/stable_yield_lab/core/repositories.py
@@ -69,10 +69,7 @@ class ReturnRepository:
             return pd.DataFrame()
         df = pd.DataFrame([row.to_dict() for row in self._rows])
         df["timestamp"] = pd.to_datetime(df["timestamp"], utc=True)
-        return (
-            df.pivot(index="timestamp", columns="name", values="period_return").sort_index()
-        )
+        return df.pivot(index="timestamp", columns="name", values="period_return").sort_index()
 
 
 __all__ = ["PoolRepository", "ReturnRepository"]
-

--- a/src/stable_yield_lab/reporting/__init__.py
+++ b/src/stable_yield_lab/reporting/__init__.py
@@ -172,7 +172,9 @@ def cross_section_report(
     metrics_index = pd.Index(df["name"], name="name") if not df.empty else pd.Index([], name="name")
     realised_metrics = pd.DataFrame(index=metrics_index)
     realised_metrics["realised_apy"] = pd.Series(float("nan"), index=metrics_index, dtype=float)
-    realised_metrics["realised_apy_observations"] = pd.Series(pd.NA, index=metrics_index, dtype="Int64")
+    realised_metrics["realised_apy_observations"] = pd.Series(
+        pd.NA, index=metrics_index, dtype="Int64"
+    )
     realised_metrics["realised_apy_warning"] = pd.Series(pd.NA, index=metrics_index, dtype="string")
     warnings_records: list[dict[str, object]] = []
 
@@ -188,7 +190,11 @@ def cross_section_report(
         returns_df = returns_df.reindex(columns=metrics_index)
         returns_df = returns_df.dropna(how="all")
 
-        if realised_apy_lookback_days is not None and realised_apy_lookback_days > 0 and not returns_df.empty:
+        if (
+            realised_apy_lookback_days is not None
+            and realised_apy_lookback_days > 0
+            and not returns_df.empty
+        ):
             cutoff = returns_df.index.max() - pd.Timedelta(days=int(realised_apy_lookback_days))
             returns_df = returns_df.loc[returns_df.index >= cutoff]
             returns_df = returns_df.dropna(how="all")

--- a/src/stable_yield_lab/visualization/visualizer.py
+++ b/src/stable_yield_lab/visualization/visualizer.py
@@ -232,9 +232,9 @@ class Visualizer:
         else:
             cash_rate = pd.Series(float(cash_returns), index=index)
 
-        cash_nav = nav_series(cash_rate.to_frame(name="cash"), initial=float(initial_investment)).rename(
-            "cash"
-        )
+        cash_nav = nav_series(
+            cash_rate.to_frame(name="cash"), initial=float(initial_investment)
+        ).rename("cash")
 
         nav_df = pd.concat([rebalanced_nav, buy_and_hold_nav, cash_nav], axis=1)
 

--- a/tests/analytics/test_metrics.py
+++ b/tests/analytics/test_metrics.py
@@ -95,5 +95,7 @@ def test_hhi_zero_total_returns_nan() -> None:
     result = hhi(df, value_col="value")
     assert math.isnan(result.loc[0, "hhi"])
 
-    grouped = hhi(pd.DataFrame({"value": [0.0], "group": ["A"]}), value_col="value", group_col="group")
+    grouped = hhi(
+        pd.DataFrame({"value": [0.0], "group": ["A"]}), value_col="value", group_col="group"
+    )
     assert math.isnan(grouped.loc[0, "hhi"])

--- a/tests/analytics/test_performance.py
+++ b/tests/analytics/test_performance.py
@@ -12,7 +12,6 @@ from stable_yield_lab.analytics.performance import (
     ScenarioRunResult,
     cumulative_return,
     nav_series,
-    nav_trajectories,
     run_rebalance_scenarios,
 )
 from stable_yield_lab.sources import HistoricalCSVSource
@@ -112,7 +111,9 @@ def test_nav_series_aligns_and_validates_weights() -> None:
 
     aligned = weights.reindex(returns.columns).fillna(0.0)
     expected_weights = aligned / aligned.sum()
-    expected_nav = 50.0 * (1.0 + returns.fillna(0.0).mul(expected_weights, axis=1).sum(axis=1)).cumprod()
+    expected_nav = (
+        50.0 * (1.0 + returns.fillna(0.0).mul(expected_weights, axis=1).sum(axis=1)).cumprod()
+    )
     pd.testing.assert_series_equal(result, expected_nav)
 
     with pytest.raises(ValueError):

--- a/tests/analytics/test_portfolio.py
+++ b/tests/analytics/test_portfolio.py
@@ -225,7 +225,9 @@ def _returns_from_fixture(raw_returns: Iterable[dict[str, object]]) -> pd.DataFr
     return frame.astype(float).set_index(index)
 
 
-def _schedule_from_fixture(raw_schedule: Iterable[dict[str, object]]) -> list[tuple[pd.Timestamp, pd.Series]]:
+def _schedule_from_fixture(
+    raw_schedule: Iterable[dict[str, object]],
+) -> list[tuple[pd.Timestamp, pd.Series]]:
     schedule: list[tuple[pd.Timestamp, pd.Series]] = []
     for entry in raw_schedule:
         ts = pd.Timestamp(entry["date"], tz="UTC")
@@ -252,7 +254,9 @@ def _simulate_nav_with_schedule(
             mask = returns.index >= start
         segment = returns.loc[mask]
         if segment.empty:
-            raise ValueError(f"no return observations available for rebalance at {start.isoformat()}")
+            raise ValueError(
+                f"no return observations available for rebalance at {start.isoformat()}"
+            )
         nav_segment = nav_series(segment, weights, initial=current_nav)
         nav_paths.append(nav_segment)
         current_nav = float(nav_segment.iloc[-1])

--- a/tests/analytics/test_risk.py
+++ b/tests/analytics/test_risk.py
@@ -197,9 +197,7 @@ def test_demo_uses_realised_returns_for_risk_metrics(
     pd.testing.assert_frame_equal(actual, expected)
 
 
-def test_demo_warns_when_history_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_demo_warns_when_history_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     csv_path = tmp_path / "pools.csv"
     history_path = tmp_path / "history.csv"
     _write_pools_csv(csv_path, ["PoolA"])

--- a/tests/reporting/test_reporting_realised_apy.py
+++ b/tests/reporting/test_reporting_realised_apy.py
@@ -13,7 +13,9 @@ def test_cross_section_report_includes_realised_apy(tmp_path: Path) -> None:
 
     repo = PoolRepository(
         [
-            Pool(name="PoolA", chain="Ethereum", stablecoin="USDC", tvl_usd=1_000_000, base_apy=0.08),
+            Pool(
+                name="PoolA", chain="Ethereum", stablecoin="USDC", tvl_usd=1_000_000, base_apy=0.08
+            ),
             Pool(name="PoolB", chain="Ethereum", stablecoin="USDT", tvl_usd=500_000, base_apy=0.07),
         ]
     )
@@ -29,7 +31,9 @@ def test_cross_section_report_includes_realised_apy(tmp_path: Path) -> None:
     )
 
     pools_df = pd.read_csv(paths["pools"])
-    assert {"realised_apy", "realised_apy_observations", "realised_apy_warning"}.issubset(pools_df.columns)
+    assert {"realised_apy", "realised_apy_observations", "realised_apy_warning"}.issubset(
+        pools_df.columns
+    )
     assert pools_df["realised_apy"].isna().all()
     warning_text = pools_df["realised_apy_warning"].fillna("")
     assert (warning_text.str.contains("Only 2 observations")).all()


### PR DESCRIPTION
## Summary
- allow the CI pre-commit step to auto-commit formatting fixes on trusted pull requests
- short-circuit the remainder of the pipeline and coverage deployment when an autofix occurs
- keep coverage deployment gated on successful formatting checks

## Testing
- poetry run pre-commit run --files .github/workflows/ci.yml

------
https://chatgpt.com/codex/tasks/task_e_68cc56107760832f8487211cd7424be3