### PR TITLE
ci: modularize workflows and fix mypy

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -1,0 +1,48 @@
+name: "Setup Poetry Environment"
+description: "Install Python, Poetry, and project dependencies"
+author: "stablecoin_quant maintainers"
+inputs:
+  python-version:
+    description: "Python version to install"
+    required: false
+    default: "3.12"
+  install-args:
+    description: "Arguments passed to 'poetry install'"
+    required: false
+    default: "--with dev --no-interaction"
+  cache-dependency-path:
+    description: "Files considered for dependency caching"
+    required: false
+    default: |
+      poetry.lock
+      pyproject.toml
+  working-directory:
+    description: "Directory containing the Poetry project"
+    required: false
+    default: "."
+runs:
+  using: "composite"
+  steps:
+    - name: "Set up Python"
+      id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: poetry
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+    - name: "Install Poetry"
+      uses: snok/install-poetry@v1
+      with:
+        version: 1.8.4
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        installer-parallel: true
+    - name: "Install dependencies"
+      working-directory: ${{ inputs.working-directory }}
+      shell: bash
+      env:
+        PYTHON_PATH: ${{ steps.setup-python.outputs.python-path }}
+      run: |
+        set -euo pipefail
+        poetry env use "$PYTHON_PATH"
+        poetry install ${{ inputs.install-args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,199 +10,36 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
-  build-test:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      precommit_autofix: ${{ steps.precommit.outputs.needs_autofix }}
-    env:
-      DEMO_OUTDIR: demo_artifacts
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  lint:
+    uses: ./.github/workflows/pre-commit.yml
+    with:
+      python-version: '3.12'
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.8.4
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
+  demo:
+    needs: lint
+    if: needs.lint.outputs.needs-autofix != 'true'
+    uses: ./.github/workflows/demo.yml
+    with:
+      python-version: '3.12'
+      artifact-name: demo-artifacts
+      demo-outdir: demo_artifacts
 
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'poetry'
-          # poetry.lock is intentionally ignored; fall back to pyproject for cache key.
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: |
-          poetry env use "${{ steps.setup-python.outputs.python-path }}"
-          poetry install --with dev --no-interaction
-
-      - name: Run pre-commit
-        id: precommit
-        run: |
-          set -eo pipefail
-          set +e
-          poetry run pre-commit run --color=always --show-diff-on-failure --all-files
-          exit_code=$?
-          set -e
-          echo "exit_code=${exit_code}" >>"${GITHUB_OUTPUT}"
-          if [ "${exit_code}" -eq 0 ]; then
-            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if git diff --quiet; then
-            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
-            exit "${exit_code}"
-          fi
-
-          echo "needs_autofix=true" >>"${GITHUB_OUTPUT}"
-
-      - name: Auto-commit pre-commit fixes
-        if: steps.precommit.outputs.needs_autofix == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "style: apply pre-commit auto-fixes"
-          branch: ${{ github.head_ref }}
-          skip_checkout: true
-
-      - name: Fail if pre-commit fixes cannot be applied automatically
-        if: steps.precommit.outputs.needs_autofix == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository)
-        run: |
-          echo '::error::pre-commit hooks modified files but CI could not push the fixes automatically.'
-          echo '::error::Please run "poetry run pre-commit run --all-files" locally and push the resulting changes.'
-          exit 1
-
-      - name: Run headless demo (config-driven)
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        env:
-          MPLBACKEND: Agg
-          STABLE_YIELD_OUTDIR: ${{ env.DEMO_OUTDIR }}
-        run: |
-          rm -rf "${STABLE_YIELD_OUTDIR}"
-          poetry run python src/stable_yield_demo.py configs/demo.toml
-          for csv_file in \
-            pools.csv \
-            by_chain.csv \
-            by_source.csv \
-            by_stablecoin.csv \
-            topN.csv \
-            concentration.csv \
-            warnings.csv \
-            portfolio_performance.csv \
-            portfolio_nav.csv
-          do
-            test -s "${STABLE_YIELD_OUTDIR}/${csv_file}"
-          done
-          test -s "${STABLE_YIELD_OUTDIR}/bar_group_chain.png"
-          if test -f "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"; then
-            test -s "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"
-          else
-            test -s "${STABLE_YIELD_OUTDIR}/scatter_tvl_apy.png"
-          fi
-          test -s "${STABLE_YIELD_OUTDIR}/yield_vs_time.png"
-          test -s "${STABLE_YIELD_OUTDIR}/nav_vs_time.png"
-
-      - name: Upload demo artifacts
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: demo-artifacts
-          path: ${{ env.DEMO_OUTDIR }}
-          if-no-files-found: error
-
-      - name: Run tests with coverage
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        run: |
-          poetry run pytest --cov=stable_yield_lab --cov-report=xml --cov-report=html --cov-report=term-missing
-
-      - name: Prepare coverage site artifact
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        run: |
-          poetry run python - <<'PY'
-            import json
-            import pathlib
-            import xml.etree.ElementTree as ET
-
-            coverage_xml = pathlib.Path("coverage.xml")
-            root = ET.fromstring(coverage_xml.read_text())
-            line_rate = float(root.get("line-rate", 0.0))
-            percentage = round(line_rate * 100, 2)
-
-            def pick_color(pct: float) -> str:
-                if pct >= 90:
-                    return "brightgreen"
-                if pct >= 75:
-                    return "green"
-                if pct >= 60:
-                    return "yellowgreen"
-                if pct >= 45:
-                    return "yellow"
-                if pct >= 30:
-                    return "orange"
-                return "red"
-
-            badge = {
-                "schemaVersion": 1,
-                "label": "coverage",
-                "message": f"{percentage:.1f}%",
-                "color": pick_color(percentage),
-            }
-
-            site_dir = pathlib.Path("coverage-site")
-            site_dir.mkdir(parents=True, exist_ok=True)
-            (site_dir / "badge.json").write_text(json.dumps(badge))
-          PY
-          rm -rf coverage-site/report
-          mkdir -p coverage-site
-          cp -r htmlcov coverage-site/report
-          cat <<'HTML' > coverage-site/index.html
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <meta http-equiv="refresh" content="0; url=report/index.html" />
-              <title>Coverage report</title>
-            </head>
-            <body>
-              <p><a href="report/index.html">View the coverage report.</a></p>
-            </body>
-          </html>
-          HTML
-
-      - name: Upload coverage artifact
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-xml
-          path: coverage.xml
-
-      - name: Upload HTML coverage artifact
-        if: steps.precommit.outputs.needs_autofix != 'true'
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-html
-          path: coverage-site/report
-
-      - name: Upload coverage site for Pages
-        if: steps.precommit.outputs.needs_autofix != 'true' && github.event_name == 'push'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: coverage-site
+  tests:
+    needs: lint
+    if: needs.lint.outputs.needs-autofix != 'true'
+    uses: ./.github/workflows/tests.yml
+    with:
+      python-version: '3.12'
+      coverage-xml-artifact: coverage-xml
+      coverage-html-artifact: coverage-html
 
   deploy-coverage:
-    needs: build-test
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/gh-pages' && needs.build-test.outputs.precommit_autofix != 'true'
+    needs: tests
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/') && github.ref != 'refs/heads/gh-pages'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/daily-demo-images.yml
+++ b/.github/workflows/daily-demo-images.yml
@@ -8,56 +8,8 @@ on:
 
 jobs:
   generate-demo-images:
-    runs-on: ubuntu-latest
-    env:
-      DEMO_OUTDIR: demo_artifacts
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          version: 1.8.4
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-          installer-parallel: true
-
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'poetry'
-          # poetry.lock is intentionally ignored; fall back to pyproject for cache key.
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies
-        run: |
-          poetry env use "${{ steps.setup-python.outputs.python-path }}"
-          poetry install --no-interaction
-
-      - name: Generate demo artifacts
-        env:
-          MPLBACKEND: Agg
-          STABLE_YIELD_OUTDIR: ${{ env.DEMO_OUTDIR }}
-        run: |
-          rm -rf "${STABLE_YIELD_OUTDIR}"
-          poetry run python src/stable_yield_demo.py configs/demo.toml
-
-          test -s "${STABLE_YIELD_OUTDIR}/bar_group_chain.png"
-          if test -f "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"; then
-            test -s "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"
-          else
-            test -s "${STABLE_YIELD_OUTDIR}/scatter_tvl_apy.png"
-          fi
-          test -s "${STABLE_YIELD_OUTDIR}/yield_vs_time.png"
-          test -s "${STABLE_YIELD_OUTDIR}/nav_vs_time.png"
-
-      - name: Upload demo artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: daily-demo-artifacts
-          path: ${{ env.DEMO_OUTDIR }}
-          if-no-files-found: error
+    uses: ./.github/workflows/demo.yml
+    with:
+      python-version: '3.12'
+      artifact-name: daily-demo-artifacts
+      demo-outdir: demo_artifacts

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,74 @@
+name: Generate Demo Artifacts
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        required: false
+        type: string
+        default: "3.12"
+      artifact-name:
+        description: "Name of the uploaded demo artifact"
+        required: false
+        type: string
+        default: "demo-artifacts"
+      demo-outdir:
+        description: "Directory used for generated demo files"
+        required: false
+        type: string
+        default: "demo_artifacts"
+
+jobs:
+  demo:
+    name: Run sample demo
+    runs-on: ubuntu-latest
+    env:
+      DEMO_OUTDIR: ${{ inputs.demo-outdir }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up project environment
+        uses: ./.github/actions/setup-project
+        with:
+          python-version: ${{ inputs.python-version }}
+          install-args: "--no-interaction"
+
+      - name: Generate demo artifacts
+        env:
+          MPLBACKEND: Agg
+          STABLE_YIELD_OUTDIR: ${{ env.DEMO_OUTDIR }}
+        run: |
+          rm -rf "${STABLE_YIELD_OUTDIR}"
+          poetry run python src/stable_yield_demo.py configs/demo.toml
+
+          for csv_file in \
+            pools.csv \
+            by_chain.csv \
+            by_source.csv \
+            by_stablecoin.csv \
+            topN.csv \
+            concentration.csv \
+            warnings.csv \
+            portfolio_performance.csv \
+            portfolio_nav.csv
+          do
+            test -s "${STABLE_YIELD_OUTDIR}/${csv_file}"
+          done
+
+          test -s "${STABLE_YIELD_OUTDIR}/bar_group_chain.png"
+          if test -f "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"; then
+            test -s "${STABLE_YIELD_OUTDIR}/scatter_risk_return.png"
+          else
+            test -s "${STABLE_YIELD_OUTDIR}/scatter_tvl_apy.png"
+          fi
+          test -s "${STABLE_YIELD_OUTDIR}/yield_vs_time.png"
+          test -s "${STABLE_YIELD_OUTDIR}/nav_vs_time.png"
+
+      - name: Upload demo artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ env.DEMO_OUTDIR }}
+          if-no-files-found: error

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,70 @@
+name: Pre-commit Checks
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        required: false
+        type: string
+        default: "3.12"
+    outputs:
+      needs-autofix:
+        description: "Whether pre-commit applied fixes"
+        value: ${{ jobs.pre_commit.outputs.needs-autofix }}
+
+jobs:
+  pre_commit:
+    name: Run pre-commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      needs-autofix: ${{ steps.precommit.outputs.needs_autofix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up project environment
+        uses: ./.github/actions/setup-project
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Run pre-commit hooks
+        id: precommit
+        shell: bash
+        run: |
+          set -eo pipefail
+          set +e
+          poetry run pre-commit run --color=always --show-diff-on-failure --all-files
+          exit_code=$?
+          set -e
+
+          if [ "$exit_code" -eq 0 ]; then
+            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          if git diff --quiet; then
+            echo "needs_autofix=false" >>"${GITHUB_OUTPUT}"
+            exit "$exit_code"
+          fi
+
+          echo "needs_autofix=true" >>"${GITHUB_OUTPUT}"
+
+      - name: Auto-commit pre-commit fixes
+        if: steps.precommit.outputs.needs_autofix == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: apply pre-commit auto-fixes"
+          branch: ${{ github.head_ref }}
+          skip_checkout: true
+
+      - name: Fail if pre-commit fixes cannot be applied automatically
+        if: steps.precommit.outputs.needs_autofix == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository)
+        run: |
+          echo '::error::pre-commit hooks modified files but CI could not push the fixes automatically.'
+          echo '::error::Please run "poetry run pre-commit run --all-files" locally and push the resulting changes.'
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,108 @@
+name: Test Suite
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        description: "Python version to use"
+        required: false
+        type: string
+        default: "3.12"
+      coverage-xml-artifact:
+        description: "Name of the uploaded coverage.xml artifact"
+        required: false
+        type: string
+        default: "coverage-xml"
+      coverage-html-artifact:
+        description: "Name of the uploaded HTML coverage artifact"
+        required: false
+        type: string
+        default: "coverage-html"
+
+jobs:
+  tests:
+    name: Run pytest with coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up project environment
+        uses: ./.github/actions/setup-project
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Run tests with coverage
+        run: |
+          poetry run pytest --cov=stable_yield_lab --cov-report=xml --cov-report=html --cov-report=term-missing
+
+      - name: Prepare coverage site artifact
+        run: |
+          poetry run python - <<'PY'
+          import json
+          import pathlib
+          import xml.etree.ElementTree as ET
+
+          coverage_xml = pathlib.Path("coverage.xml")
+          root = ET.fromstring(coverage_xml.read_text())
+          line_rate = float(root.get("line-rate", 0.0))
+          percentage = round(line_rate * 100, 2)
+
+          def pick_color(pct: float) -> str:
+              if pct >= 90:
+                  return "brightgreen"
+              if pct >= 75:
+                  return "green"
+              if pct >= 60:
+                  return "yellowgreen"
+              if pct >= 45:
+                  return "yellow"
+              if pct >= 30:
+                  return "orange"
+              return "red"
+
+          badge = {
+              "schemaVersion": 1,
+              "label": "coverage",
+              "message": f"{percentage:.1f}%",
+              "color": pick_color(percentage),
+          }
+
+          site_dir = pathlib.Path("coverage-site")
+          site_dir.mkdir(parents=True, exist_ok=True)
+          (site_dir / "badge.json").write_text(json.dumps(badge))
+          PY
+          rm -rf coverage-site/report
+          mkdir -p coverage-site
+          cp -r htmlcov coverage-site/report
+          cat <<'HTML' > coverage-site/index.html
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="refresh" content="0; url=report/index.html" />
+              <title>Coverage report</title>
+            </head>
+            <body>
+              <p><a href="report/index.html">View the coverage report.</a></p>
+            </body>
+          </html>
+          HTML
+
+      - name: Upload coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.coverage-xml-artifact }}
+          path: coverage.xml
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.coverage-html-artifact }}
+          path: coverage-site/report
+
+      - name: Upload coverage site for Pages
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: coverage-site

--- a/src/stable_yield_lab/analytics/attribution.py
+++ b/src/stable_yield_lab/analytics/attribution.py
@@ -26,7 +26,7 @@ def _ensure_datetime_index(index: pd.Index, *, label: str) -> pd.DatetimeIndex:
         dt_index = index
     else:
         dt_index = pd.to_datetime(index, utc=True, errors="coerce")
-    if dt_index.isna().any():  # type: ignore[truthy-function]
+    if dt_index.isna().any():
         raise TypeError(f"{label} index must be datetime-like")
     return pd.DatetimeIndex(dt_index).sort_values()
 

--- a/src/stable_yield_lab/reporting/__init__.py
+++ b/src/stable_yield_lab/reporting/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pandas as pd
 
@@ -345,24 +346,24 @@ def cross_section_report(
             return {col: float("nan") for col in _RISK_COLUMNS}
         return {col: values.get(col, float("nan")) for col in _RISK_COLUMNS}
 
-    conc_records: list[dict[str, float]] = []
+    conc_records: list[dict[str, float | str]] = []
 
     total_hhi = float(hhi_total["hhi"].iloc[0]) if not hhi_total.empty else float("nan")
-    record = {"scope": "total", "hhi": total_hhi}
+    record = cast(dict[str, float | str], {"scope": "total", "hhi": total_hhi})
     record.update(_metrics_for("total"))
     conc_records.append(record)
 
     if not hhi_chain.empty:
         for _, row in hhi_chain.iterrows():
             scope = f"chain:{row['chain']}"
-            record = {"scope": scope, "hhi": float(row["hhi"])}
+            record = cast(dict[str, float | str], {"scope": scope, "hhi": float(row["hhi"])})
             record.update(_metrics_for(scope))
             conc_records.append(record)
 
     if not hhi_stable.empty:
         for _, row in hhi_stable.iterrows():
             scope = f"stablecoin:{row['stablecoin']}"
-            record = {"scope": scope, "hhi": float(row["hhi"])}
+            record = cast(dict[str, float | str], {"scope": scope, "hhi": float(row["hhi"])})
             record.update(_metrics_for(scope))
             conc_records.append(record)
 
@@ -370,7 +371,7 @@ def cross_section_report(
     for scope, values in metrics_map.items():
         if scope in existing_scopes:
             continue
-        record = {"scope": scope, "hhi": float("nan")}
+        record = cast(dict[str, float | str], {"scope": scope, "hhi": float("nan")})
         record.update({col: values.get(col, float("nan")) for col in _RISK_COLUMNS})
         conc_records.append(record)
 


### PR DESCRIPTION
## Summary
- add a reusable composite action and workflows to set up the project, run pre-commit, tests, and the demo
- refactor the main CI pipeline and daily demo workflow to call the reusable jobs and keep forked PRs working
- clean up analytics/reporting typing to satisfy mypy without ignores

## Testing
- pytest -q
- pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cc613f6a5c832fa813dee519124707