### PR TITLE
fix: configure pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Configure GitHub Pages
+        # Provision the Pages site if it has not been set up yet.
+        uses: actions/configure-pages@v4
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- configure the Pages site before deploying coverage artifacts to GitHub Pages

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cc78319448832f9f8595f1f578c27d