### PR TITLE
fix: serve coverage report from stable pages paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Configure GitHub Pages
+        # Provision the Pages site if it has not been set up yet.
+        uses: actions/configure-pages@v4
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,9 @@ jobs:
           poetry run python - <<'PY'
           import json
           import pathlib
+          import shutil
           import xml.etree.ElementTree as ET
+          from textwrap import dedent
 
           coverage_xml = pathlib.Path("coverage.xml")
           root = ET.fromstring(coverage_xml.read_text())
@@ -100,25 +102,50 @@ jobs:
           }
 
           site_dir = pathlib.Path("coverage-site")
-          site_dir.mkdir(parents=True, exist_ok=True)
-          (site_dir / "badge.json").write_text(json.dumps(badge))
+          htmlcov_dir = pathlib.Path("htmlcov")
+          report_dir = site_dir / "report"
+          coverage_dir = site_dir / "coverage"
+
+          if not htmlcov_dir.exists():
+              raise SystemExit("Expected htmlcov directory to exist")
+
+          if site_dir.exists():
+              shutil.rmtree(site_dir)
+
+          report_dir.mkdir(parents=True, exist_ok=True)
+          coverage_dir.mkdir(parents=True, exist_ok=True)
+
+          shutil.copytree(htmlcov_dir, report_dir, dirs_exist_ok=True)
+
+          for target in (site_dir / "badge.json", coverage_dir / "badge.json"):
+              target.parent.mkdir(parents=True, exist_ok=True)
+              target.write_text(json.dumps(badge))
+
+          (site_dir / ".nojekyll").write_text("")
+
+          redirect_template = dedent(
+              """\
+              <!doctype html>
+              <html lang="en">
+                <head>
+                  <meta charset='utf-8' />
+                  <meta http-equiv='refresh' content='0; url={target}' />
+                  <title>Coverage report</title>
+                </head>
+                <body>
+                  <p><a href='{target}'>View the coverage report.</a></p>
+                </body>
+              </html>
+              """
+          )
+
+          (site_dir / "index.html").write_text(
+              redirect_template.format(target="report/index.html")
+          )
+          (coverage_dir / "index.html").write_text(
+              redirect_template.format(target="../report/index.html")
+          )
           PY
-          rm -rf coverage-site/report
-          mkdir -p coverage-site
-          cp -r htmlcov coverage-site/report
-          cat <<'HTML' > coverage-site/index.html
-          <!doctype html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <meta http-equiv="refresh" content="0; url=report/index.html" />
-              <title>Coverage report</title>
-            </head>
-            <body>
-              <p><a href="report/index.html">View the coverage report.</a></p>
-            </body>
-          </html>
-          HTML
 
       - name: Upload coverage XML
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Experimental toolkit for analyzing and visualizing yields on stablecoin pools.
 
-Latest test coverage is published automatically from CI to [GitHub Pages](https://aujl.github.io/stablecoin_quant/coverage/), which hosts the HTML report alongside the badge metadata for the shield above.
+Latest test coverage is published automatically from CI to [GitHub Pages](https://aujl.github.io/stablecoin_quant/coverage/), which redirects to the full [HTML report](https://aujl.github.io/stablecoin_quant/report/index.html) and hosts the badge metadata for the shield above.
 
 ## Project Layout
 


### PR DESCRIPTION
## Summary
- rebuild the coverage site artifact in CI so the deployed Pages bundle includes `.nojekyll`, redirect landing pages, and a duplicate `badge.json` under `/coverage/`
- document the GitHub Pages coverage URL and explicit HTML report link in the README

## Testing
- poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc78319448832f9f8595f1f578c27d